### PR TITLE
docs: expand module 1 with CLI literacy and CLAUDE.md basics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,9 +182,9 @@ cython_debug/
 .abstra/
 
 # Visual Studio Code
-#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
-#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#  and can be added to the global gitignore or merged into this file. However, if you prefer,
 #  you could uncomment the following to ignore the entire vscode folder
 # .vscode/
 
@@ -206,3 +206,5 @@ marimo/_static/
 marimo/_lsp/
 __marimo__/
 *.local.*
+docs/plans/
+docs/specs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,19 +1,36 @@
-This repository contains a structure Claude Code workshop. 
-The repository contains branches for each module that will progressively introduce further agentic configuration components. 
-As we build out our application the user will merge the changes from the lower module into the higher modules allowing the agentic features we have configured to be utilized on the applications that are being built. 
+# Todd — Claude Code Workshop
 
-# Quick start
+Todd is a Typer CLI application built progressively through a structured Claude Code
+workshop. Each module introduces new agentic capabilities — from project scaffolding
+to parallel agent teams.
 
-*TBD*
-
-
-# Tech Stack
+## Tech Stack
 
 - Python: 3.13+
-- Package Management: uv
+- Package management: uv
+- CLI framework: Typer
 - Tests: pytest
 - Hooks: pre-commit (ruff, mypy strict, bandit, vulture, xenon)
 
-# Ruff: 
-    
-- rules: E, W, F, I, N, UP,  B, C4, PLC, PLE, PLW, RUF
+## Development Commands
+
+```shell
+# Run the CLI
+uv run todd
+
+# Run tests
+uv run pytest
+
+# Type checking
+uv run mypy src/
+
+# Linting
+uv run ruff check src/ tests/
+```
+
+## Coding Standards
+
+- **Ruff** rules: E, W, F, I, N, UP, B, C4, PLC, PLE, PLW, RUF
+- **mypy** strict mode — all functions must have complete type annotations
+- **Conventional commits** — `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`
+- Prefer simple, readable code over clever abstractions

--- a/modules/module1.md
+++ b/modules/module1.md
@@ -96,9 +96,93 @@ terminal. In the chat box, run:
 
 ---
 
-## 5. Commit and Proceed
+## 5. CLI Navigation Essentials
 
-Ask Claude to commit the changes, then advance to the next module:
+Now that the project is scaffolded, let's learn the shortcuts you'll use every day.
+
+**`@` file references** — type `@pyproject.toml` in the chat box to reference a file
+without copying its full content. Claude reads the file on demand.
+
+**`!` bash mode** — prefix with `!` to run shell commands directly (you already used
+this in step 3). It's shorthand for asking Claude to run a Bash tool call.
+
+**Multiline input** — `\` + Enter for a quick line continuation, or `Shift+Enter` for
+a new line in the prompt.
+
+**`Ctrl+G`** — open the current prompt in your default text editor for longer edits.
+
+> **Exercise:** Type `@src/todd/__init__.py` to reference the init file, then run
+> `!uv run todd hello` to verify the CLI still works.
+
+---
+
+## 6. Permission Modes
+
+Claude Code has three permission modes, cycled with `Shift+Tab`:
+
+| Mode | Status line | Behavior |
+|------|-------------|----------|
+| **Normal** (default) | No indicator | Prompts for confirmation on file edits and shell commands |
+| **Auto-Accept** | `⚡ auto-accept` | Skips file edit confirmations; still prompts for shell commands |
+| **Plan** | `⏸ plan mode` | Read-only — Claude explores and plans but cannot write or edit files |
+
+> **Callout:** You'll use Plan mode extensively in Module 2. For now, cycle through the
+> modes with `Shift+Tab` to see the status line update.
+
+---
+
+## 7. Essential Commands
+
+Claude Code ships with built-in slash commands. Here are the ones you'll use most:
+
+| Command | What it does |
+|---------|-------------|
+| `/context` | Visual grid showing context window usage |
+| `/cost` | Token usage and cost for this session |
+| `/compact` | Compress conversation to free context — use when responses degrade |
+| `/clear` | Reset context entirely between unrelated tasks |
+| `/help` | Full command list |
+
+> **Exercise:** Run `/context` and `/cost` to see your current session state.
+> You'll revisit these throughout the workshop as context management becomes critical.
+
+---
+
+## 8. Your First CLAUDE.md
+
+CLAUDE.md is the single most impactful Claude Code feature. It provides persistent
+project instructions that load automatically every session.
+
+**Three scopes:**
+
+| Scope | File | Shared via git? |
+|-------|------|----------------|
+| Global (all projects) | `~/.claude/CLAUDE.md` | No |
+| Project (team-wide) | `./CLAUDE.md` | Yes |
+| Personal (local only) | `./CLAUDE.md.local` | No (gitignored) |
+
+**Exercise:** Update the project `CLAUDE.md` with proper structure:
+
+```markdown
+Update the project CLAUDE.md to include:
+- Project description: todd is a Typer CLI application built as part of the Claude Code workshop
+- Tech stack: Python 3.13+, uv, pytest, Typer
+- How to run tests: uv run pytest
+- How to run the CLI: uv run todd
+- Coding standards: ruff (rules E, W, F, I, N, UP, B, C4, PLC, PLE, PLW, RUF), mypy strict
+- Commit conventions: conventional commits
+```
+
+> **Callout:** This CLAUDE.md will shape Claude's behavior for the rest of the workshop.
+> Every module builds on it. A well-written CLAUDE.md eliminates the need to repeat
+> project context in every prompt.
+
+---
+
+## 9. Commit and Proceed
+
+Ask Claude to commit the changes (including the CLAUDE.md update), then advance to
+the next module:
 
 ```markdown
 Commit the changes and then run /module to proceed to module 2.


### PR DESCRIPTION
## Summary
- Add steps 5-8 to module 1: CLI navigation essentials, permission modes, essential commands, and first CLAUDE.md setup
- Replace CLAUDE.md stub with foundational project configuration (tech stack, dev commands, coding standards)
- Update .gitignore with docs/plans/ and docs/specs/ entries

## Test plan
- [ ] Verify section numbering is consecutive (1-9)
- [ ] Verify `[Module 2 →](module2.md)` navigation link at bottom
- [ ] Verify CLAUDE.md matches what Module 1 Step 8 teaches students to write