### PR TITLE
docs: add workshop navigation explanation to README and slides

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ As we progress through the course we will use the `/module` command in Claude to
 This will allow us to slowly introduce topics and focus on key aspects of the tool and agentic coding as we progress.
 
 
+## How Modules Work
+
+Each module lives in `modules/moduleN.md` and walks you through the exercises for that milestone.
+When you finish a module, run `/module` in Claude Code — it merges your current branch forward into the next module branch, carrying everything you've built with it.
+This keeps each module self-contained while letting your work accumulate naturally across the workshop.
+
 ## Get Started
 
 When you're ready proceed to [Module1](modules/module1.md).

--- a/docs/generate_slides.py
+++ b/docs/generate_slides.py
@@ -72,7 +72,7 @@ class TwoColumnSlide(SlideData):
     right: list[Bullet] = field(default_factory=list)
 
 
-# All 36 slides in exact order
+# All 37 slides in exact order
 SLIDES: list[SlideData] = [
     # Slide 1: Title slide
     TitleSlide(
@@ -123,7 +123,34 @@ SLIDES: list[SlideData] = [
         ],
         notes="Frame this as a hands-on journey. Where we'll progressively build up capabilities and complexity. Transition: Let's start with what Claude Code actually is.",
     ),
-    # Slide 5: What Is Claude Code?
+    # Slide 5: How Modules Work
+    ContentSlide(
+        title="How Modules Work",
+        bullets=[
+            (
+                "Each module has a guide: ",
+                "`modules/moduleN.md` — follow it step by step",
+                0,
+            ),
+            (
+                "When you finish a module: ",
+                "run `/module` in Claude Code to advance",
+                0,
+            ),
+            (
+                "What `/module` does: ",
+                "merges your branch forward into the next module branch",
+                0,
+            ),
+            (
+                "Your work carries forward: ",
+                "each module builds on everything you've built so far",
+                0,
+            ),
+        ],
+        notes="Orient participants before they start. The module files are the source of truth for exercises — they follow those, not the slides. The /module command is the transition mechanism: it merges the current branch into the next, so nothing is lost. Participants work at their own pace; the command handles the git logistics.",
+    ),
+    # Slide 6: What Is Claude Code?
     ContentSlide(
         title="What Is Claude Code?",
         bullets=[
@@ -150,7 +177,7 @@ SLIDES: list[SlideData] = [
         ],
         notes="Claude Code is not a chatbot — it's an agentic tool that operates on your codebase. It reads files, writes code, runs commands, and manages its own workflow through subagents. The extensibility layers — MCP, commands, skills, hooks, agents — are what make it a platform, not just a tool. Each of these extension points will get dedicated coverage in later modules. Transition: Before diving into the modules, let's establish the vocabulary.",
     ),
-    # Slide 6: Core Concepts (1/2)
+    # Slide 7: Core Concepts (1/2)
     TwoColumnSlide(
         title="Core Concepts (1/2)",
         left=[
@@ -164,7 +191,7 @@ SLIDES: list[SlideData] = [
         right=["These concepts thread through every module."],
         notes="Context is finite and precious. Everything we build in the workshop is designed to manage it well. Transition: The next concepts are about how we structure agent work.",
     ),
-    # Slide 7: Core Concepts (2/2)
+    # Slide 8: Core Concepts (2/2)
     TwoColumnSlide(
         title="Core Concepts (2/2)",
         left=[
@@ -177,12 +204,12 @@ SLIDES: list[SlideData] = [
         right=["These concepts define how agents work at scale."],
         notes="These concepts define how agents work at scale. We'll see each one in practice as we progress through the modules. Transition: Let's start building. Module 1.",
     ),
-    # Slide 8: Module 1 Section Header
+    # Slide 9: Module 1 Section Header
     SectionSlide(
         title="Module 1: Project Scaffolding",
         notes="Module 1 establishes the foundation. Everything built here — the project structure, quality gates, CLAUDE.md — persists through all subsequent modules. The key insight is that Claude is a general-purpose agentic tool: describe what you want in natural language, get a working project with quality enforcement from commit one. Transition: Here's what we actually do.",
     ),
-    # Slide 9: M1 What We Do
+    # Slide 10: M1 What We Do
     ContentSlide(
         title="Let's get to work",
         bullets=[
@@ -190,7 +217,7 @@ SLIDES: list[SlideData] = [
         ],
         notes="Participants follow the steps in module1.md at their own pace. Flag down an assistant if you get stuck.",
     ),
-    # Slide 10: M1 Why It Matters
+    # Slide 11: M1 Why It Matters
     ContentSlide(
         title="Summarizing what we have seen",
         bullets=[
@@ -217,12 +244,12 @@ SLIDES: list[SlideData] = [
         ],
         notes="Describe what you want, Claude handles the rest. Pre-commit hooks are back pressure before we even name it. CLAUDE.md shaped everything Claude just did. Transition: Module 2 introduces context management and planning.",
     ),
-    # Slide 11: Module 2 Section Header
+    # Slide 12: Module 2 Section Header
     SectionSlide(
         title="Module 2: MCP, Plan Mode, and Agent SDK",
         notes="Module 2 introduces the critical concept of context as a finite resource. You'll install your first MCP server, see how it affects context usage, switch models for planning, and build a real feature through plan mode. The key progression: Module 1 was about Claude doing things for you. Module 2 is about Claude thinking before doing. Transition: What we do in this module.",
     ),
-    # Slide 12: M2 What We Do
+    # Slide 13: M2 What We Do
     ContentSlide(
         title="Let's get to work",
         bullets=[
@@ -230,19 +257,19 @@ SLIDES: list[SlideData] = [
         ],
         notes="Participants follow the steps in module2.md at their own pace. Flag down an assistant if you get stuck.",
     ),
-    # Slide 13: The Context Window (with image)
+    # Slide 14: The Context Window (with image)
     ImageSlide(
         title="The Context Window",
         image="images/context_window_utilization.png",
         notes="This is the most important conceptual slide. Walk through each layer. System prompt and CLAUDE.md are always present — they're the 'tax' on every interaction. Tool definitions from MCP servers add up (Context7 alone adds several hundred tokens). Conversation history is the biggest consumer — this is why /compact and /clear matter. File contents are loaded on demand but can be huge. The 'available space' is what Claude has for actual reasoning. When it shrinks too much, that's context rot in action. Transition: Now let's see how subagents protect this window.",
     ),
-    # Slide 14: Subagent Context Isolation (with image)
+    # Slide 15: Subagent Context Isolation (with image)
     ImageSlide(
         title="Subagent Context Isolation",
         image="images/subagent_context_savings.png",
         notes="This diagram shows how subagents protect the main context window. When Claude needs to search 40+ files or do deep research, it spawns a subagent — typically Haiku for cheap exploration, Opus for architecture decisions. Each subagent gets its own fresh context window. The search noise (file contents, failed matches, irrelevant results) stays in the subagent's window. Only a compact summary flows back to the main conversation. This is the primary defense against context rot: delegate the noisy work, keep the main window clean. Point out the three subagent types: two Explore agents running Haiku for fast, cheap searches, and one Plan agent running Opus for deeper reasoning. Transition: Module 3 builds the orchestration layer.",
     ),
-    # Slide 15: M2 Summary
+    # Slide 16: M2 Summary
     ContentSlide(
         title="Summarizing what we have seen",
         bullets=[
@@ -270,12 +297,12 @@ SLIDES: list[SlideData] = [
         ],
         notes="Context is finite and precious. Rot happens gradually (long sessions). Poisoning happens suddenly (one bad assumption). Subagents are the primary defense against both — each gets a fresh context window. MCP token cost is a real tradeoff: more tools = more capability but less context space. Model selection is about cost-quality tradeoffs, not just 'use the best model.' Transition: Module 3 builds the orchestration layer.",
     ),
-    # Slide 16: Module 3 Section Header
+    # Slide 17: Module 3 Section Header
     SectionSlide(
         title="Module 3: ADW Foundations",
         notes="Module 3 builds the full extensibility layer. We create commands, skills, hooks, rules, and custom agents — all in .claude/. The key insight: all of this is markdown and configuration — no code. Claude's behavior is shaped by prose instructions, not programming. This is prompt-driven orchestration. Transition: What we do.",
     ),
-    # Slide 17: M3 What We Do (1/2)
+    # Slide 18: M3 What We Do (1/2)
     ContentSlide(
         title="M3: What We Do (1/2)",
         bullets=[
@@ -288,7 +315,7 @@ SLIDES: list[SlideData] = [
         ],
         notes="The ARD generation is a powerful demo of Claude as a non-coding tool. It reads the existing ADW spec and produces a visual reference with 5 Mermaid diagrams. The document-skills plugin adds capabilities like PowerPoint and Word generation — installed at project scope so the whole team gets it. When planning the orchestration commands, Claude reads the existing phase commands to understand the composition patterns. This is plan mode used for configuration, not code. Transition: The commands we build.",
     ),
-    # Slide 18: M3 What We Do (2/2)
+    # Slide 19: M3 What We Do (2/2)
     ContentSlide(
         title="M3: What We Do (2/2)",
         bullets=[
@@ -309,7 +336,7 @@ SLIDES: list[SlideData] = [
         ],
         notes="The four commands compose the seven existing phase commands. /feature and /bug are sequential — one phase at a time. /team:feature and /team:bug spawn parallel workers for analysis, then coordinate implementation. Custom agents are created alongside commands — each agent gets its own model, tool allowlist, skills, and constraints. All defined in markdown, no code. The PostToolUse hook runs ruff + mypy after every file write — this is back pressure in action. .claude/rules/ adds path-specific context (e.g., different rules for src/ vs tests/). Transition: Why these patterns matter.",
     ),
-    # Slide 19: M3 Why It Matters
+    # Slide 20: M3 Why It Matters
     ContentSlide(
         title="M3: Why It Matters",
         bullets=[
@@ -333,13 +360,13 @@ SLIDES: list[SlideData] = [
         ],
         notes="The commands-vs-skills distinction is a key design decision. Commands are explicit — the user or orchestrator invokes them. Skills are implicit — Claude loads them when the task matches. Custom agents are the third extensibility primitive — each scoped with its own model, tools, and constraints. Back pressure via hooks closes the loop immediately: write bad code, get feedback instantly, fix before moving on. The entire system is defined in markdown — no Python, no YAML, just prose. Transition: Let's visualize the four-layer context system.",
     ),
-    # Slide 20: The Four-Layer Context System (with image)
+    # Slide 21: The Four-Layer Context System (with image)
     ImageSlide(
         title="The Four-Layer Context System",
         image="images/fourlayer_context_system.png",
         notes="This is the architectural insight of Module 3. The four layers form a progressive disclosure system. CLAUDE.md is always present (broad but essential). Rules narrow to specific directories. Skills narrow to specific task types. Hooks narrow to specific actions. The key insight: context is delivered at the moment it's needed, at the right scope. This prevents context bloat while ensuring Claude always has what it needs. Transition: Let's dig deeper into when progressive disclosure works and when it doesn't.",
     ),
-    # Slide 21: Progressive Disclosure — When & When Not
+    # Slide 22: Progressive Disclosure — When & When Not
     TwoColumnSlide(
         title="Progressive Disclosure",
         left=[
@@ -360,7 +387,7 @@ SLIDES: list[SlideData] = [
         ],
         notes="Progressive disclosure is the difference between a productive session and context rot. Left side: the Four-Layer system we just saw. CLAUDE.md is always-on. Rules fire by directory. Skills fire by task type. Hooks fire by event. Each layer narrows scope. Right side: the anti-patterns. The worst is front-loading everything — Claude's attention degrades when buried under irrelevant context. Nielsen Norman research shows 3+ disclosure levels cause confusion even for humans. The last anti-pattern is important: progressive disclosure doesn't mean hiding information — it means delivering it at the right time. If an agent needs reference docs NOW, load them NOW. Transition: The other side of quality — back pressure.",
     ),
-    # Slide 22: Back Pressure — Three Layers
+    # Slide 23: Back Pressure — Three Layers
     ContentSlide(
         title="Back Pressure: Three Layers",
         bullets=[
@@ -390,18 +417,18 @@ SLIDES: list[SlideData] = [
         ],
         notes="Back pressure means the system actively resists bad output. Three layers, each catching different problems at different times. Immediate: PostToolUse hooks fire after EVERY file write — the agent sees lint errors within seconds and self-corrects. Pre-commit hooks block the commit entirely. Workflow-level: TDD is the strongest back pressure — you can't claim 'done' if tests fail. Plan mode prevents the most expensive mistake: writing code before thinking. Spec-driven development means the PRD is the contract — anything not in the spec gets rejected. Post-hoc: CI/CD and code review catch what slipped through. Key principle: the earlier you catch problems, the cheaper they are to fix. A PostToolUse lint error costs seconds. A failed CI check costs minutes. A post-merge bug costs hours. Transition: Module 4 puts it all together.",
     ),
-    # Slide 23: Anatomy of a Custom Agent (with image)
+    # Slide 24: Anatomy of a Custom Agent (with image)
     ImageSlide(
         title="Anatomy of a Custom Agent",
         image="images/agent_anatomy.png",
         notes="Walk through each field. Name and description control when Claude delegates to this agent. Model selection is a cost decision — Haiku for cheap read-only analysis. Tools is an allowlist — the agent can ONLY use these tools, nothing else. permissionMode controls whether the agent can act without confirmation. maxTurns prevents runaway execution. skills preloads specific skills into the agent's context. The system prompt body (below the frontmatter) is where you define the agent's behavior, output format, and constraints. This is agent design as API design: clear inputs, clear outputs, single responsibility. Transition: Module 4 puts it all together.",
     ),
-    # Slide 24: Module 4 Section Header
+    # Slide 25: Module 4 Section Header
     SectionSlide(
         title="Module 4: Agentic Delivery Workflows",
         notes="Module 4 is where everything comes together. You'll run the orchestration commands from Module 3 against real PRDs, in parallel worktrees, and observe the difference between single-agent and team execution. This is the practical payoff of all the scaffolding work. Transition: What we do.",
     ),
-    # Slide 25: M4 What We Do (1/2)
+    # Slide 26: M4 What We Do (1/2)
     ContentSlide(
         title="M4: What We Do (1/2)",
         bullets=[
@@ -414,7 +441,7 @@ SLIDES: list[SlideData] = [
         ],
         notes="This is the most hands-on module. Two terminals running simultaneously — one with team coordination, one sequential. claude -w creates an isolated worktree automatically. Emphasize that both instances are reading the same PRDs but executing through different orchestration patterns. The worktree isolation means they can modify the same file paths without conflicts. If time is tight, run one terminal live and demo the other. Transition: What to observe.",
     ),
-    # Slide 26: M4 What We Do (2/2)
+    # Slide 27: M4 What We Do (2/2)
     ContentSlide(
         title="M4: What We Do (2/2)",
         bullets=[
@@ -433,7 +460,7 @@ SLIDES: list[SlideData] = [
         ],
         notes="The observable difference between team and single-agent is the activity pattern. Team runs show bursts (4 workers analyzing simultaneously) followed by pauses (leader synthesizing). Single-agent shows steady progress. State files bridge phases — each phase reads the previous output from state.json. Session log analysis reveals coordination overhead in team runs vs. serial efficiency in single-agent. Both approaches produce working code — the question is which pattern fits your use case. Transition: Why these patterns matter.",
     ),
-    # Slide 27: M4 Why It Matters (1/2)
+    # Slide 28: M4 Why It Matters (1/2)
     ContentSlide(
         title="M4: Why It Matters (1/2)",
         bullets=[
@@ -460,7 +487,7 @@ SLIDES: list[SlideData] = [
         ],
         notes="Two orchestration patterns: code-driven (Python script chains phases via subprocess) and team-driven (leader coordinates workers via SendMessage). Worktrees are the filesystem isolation layer — the first of four sandboxing layers. State files are the glue: they carry the ADW ID, completed phases, plan file path, and issue description between phases. This makes each phase independently resumable. Transition: The deeper principles.",
     ),
-    # Slide 28: M4 Why It Matters (2/2)
+    # Slide 29: M4 Why It Matters (2/2)
     ContentSlide(
         title="M4: Why It Matters (2/2)",
         bullets=[
@@ -487,18 +514,18 @@ SLIDES: list[SlideData] = [
         ],
         notes="Sandboxing layers up: worktrees protect the filesystem, subagents protect the context window, hooks protect code quality, permission modes protect system access. Each layer limits what can go wrong at a different scope. Agent design is API design — the better defined the interface, the more reliably agents compose. 'Tools build tools' is a meta-pattern: the commands we built in Module 3 were used to build the orchestrator scripts in Module 4. Three feedback layers give different perspectives: hooks tell you WHAT went wrong (lint error), phase transitions tell you WHEN (which phase failed), session logs tell you WHY (full behavioral trace). Transition: Let's compare the two execution models.",
     ),
-    # Slide 29: Single-Agent vs Team Execution (with image)
+    # Slide 30: Single-Agent vs Team Execution (with image)
     ImageSlide(
         title="Single-Agent vs Team Execution",
         image="images/single_agent_vs_team.png",
         notes="This is the comparison table participants should take away. Single-agent is simpler, more predictable, easier to debug. Team is faster for analysis (parallel workers), but adds coordination overhead. The key question isn't 'which is better' but 'which fits your task.' Simple bugs? Single-agent. Complex features with independent analysis areas? Team. The overhead of leader synthesis is only worth it when the analysis phases are truly independent. Transition: Module 5 covers the operational side.",
     ),
-    # Slide 30: Module 5 Section Header
+    # Slide 31: Module 5 Section Header
     SectionSlide(
         title="Module 5: Operations & Maintenance",
         notes="Module 5 is about sustained use. Headless mode for CI/CD, session management, cost awareness, and CLAUDE.md maintenance. These are the practices that make Claude Code reliable over weeks and months, not just during a workshop. Transition: What we do.",
     ),
-    # Slide 31: M5 What We Do (1/2)
+    # Slide 32: M5 What We Do (1/2)
     ContentSlide(
         title="M5: What We Do (1/2)",
         bullets=[
@@ -511,7 +538,7 @@ SLIDES: list[SlideData] = [
         ],
         notes="Headless mode is what makes Claude useful in pipelines — no chat box, no confirmations, just input/output. The custom agents defined in Module 3 are the building blocks here: they run autonomously shaped only by CLAUDE.md and their own frontmatter configuration. Piping content is a powerful pattern: feed any text to Claude for analysis. Emphasize the --dangerously-skip-permissions flag name: it's intentionally scary because you're removing a safety layer. Transition: Session management and cost.",
     ),
-    # Slide 32: M5 What We Do (2/2)
+    # Slide 33: M5 What We Do (2/2)
     ContentSlide(
         title="M5: What We Do (2/2)",
         bullets=[
@@ -524,7 +551,7 @@ SLIDES: list[SlideData] = [
         ],
         notes="Sessions persist locally — you can resume any previous session by name or ID. Named sessions make it easy to return to specific work threads. Cost tracking is essential for sustained use — /cost shows the current session, /stats shows daily patterns. Effort levels let you match reasoning depth to task complexity: Low for typos, Medium for most work, High for architecture. Extended thinking gives Claude a scratchpad for longer reasoning chains. Checkpointing is the safety net: Claude snapshots before every action, so you can rewind code, conversation, or both. Transition: The principles behind operations.",
     ),
-    # Slide 33: M5 Why It Matters
+    # Slide 34: M5 Why It Matters
     ContentSlide(
         title="M5: Why It Matters",
         bullets=[
@@ -552,13 +579,13 @@ SLIDES: list[SlideData] = [
         ],
         notes="In CI/CD, Claude runs headless with only CLAUDE.md for guidance — the agents defined in Module 3 power this. This is why CLAUDE.md maintenance matters so much. Session persistence means you can pick up where you left off across days. Cost awareness prevents surprise bills — match the model to the task. Checkpointing is the ultimate safety net for experimentation. CLAUDE.md maintenance is ongoing: stale references, contradictory instructions, and vague directives all degrade Claude's performance. Transition: Let's see the big picture.",
     ),
-    # Slide 34: The Progression (with image)
+    # Slide 35: The Progression (with image)
     ImageSlide(
         title="The Progression",
         image="images/progression.png",
         notes="This is the retrospective view. Each module builds on the previous. Module 1 gives you the foundation (project + CLAUDE.md). Module 2 adds context awareness and planning discipline. Module 3 builds the orchestration primitives. Module 4 puts them together with parallel execution. Module 5 adds the operational practices for sustained use. The progression mirrors how you'd adopt Claude Code in practice: start with scaffolding, add planning, build workflows, scale with teams, operationalize. Transition: Let's recap the core concepts.",
     ),
-    # Slide 35: 10 Core Concepts Recap
+    # Slide 36: 10 Core Concepts Recap
     TwoColumnSlide(
         title="10 Core Concepts Recap",
         left=[
@@ -577,7 +604,7 @@ SLIDES: list[SlideData] = [
         ],
         notes="Quick recap of all ten concepts. Ask participants to call out which modules demonstrated each concept. Context Engineering: every module. Context Rot: Module 2. Context Poisoning: Module 2. Progressive Disclosure: Modules 3-4. Dynamic Context Injection: Module 3. Skills vs Commands: Module 3. Agent Design: Modules 4-5. Back Pressure: Modules 1, 3. Sandboxing: Module 4. Agent Teams: Module 4. Transition: Questions?",
     ),
-    # Slide 36: Closing
+    # Slide 37: Closing
     SectionSlide(
         title="Questions?",
         layout=LAYOUT_CLOSING,

--- a/modules/module1.md
+++ b/modules/module1.md
@@ -132,7 +132,7 @@ In the chat box, run:
 > You'll see the active model, how much of the context window is in use, your working directory, and the git status.
 > This HUD becomes more useful in later modules as context management and model switching become part of your workflow.
 > There are many other built-in slash commands you can see if you just type `/` in the chat window.
-> For a full list, see the [Anthropic docs on slash commands](https://docs.anthropic.com/en/docs/claude-code/cli-usage#slash-commands).
+> For a full list, see the [Anthropic docs on slash commands](https://code.claude.com/docs/en/interactive-mode#built-in-commands).
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds \"How Modules Work\" section to README explaining the modules/moduleN.md + /module workflow
- Adds matching slide 5 to the deck with the same content
- Renumbers all subsequent slides (36 → 37 total)
- Fixes stale slash commands docs URL in module1.md

## Test plan
- [ ] Verify `uv run docs/generate_slides.py` produces 37 slides without errors
- [ ] Confirm README renders correctly on GitHub