### PR TITLE
feat(module1): add navigation tip callouts and reframe M5 as take-home

### DIFF
--- a/docs/generate_slides.py
+++ b/docs/generate_slides.py
@@ -119,7 +119,7 @@ SLIDES: list[SlideData] = [
             "M2: Build a simple CLI LLM tool called todd",
             "M3: Build orchestration commands, agents, hooks, and skills",
             "M4: Run parallel agent teams in isolated worktrees",
-            "M5: Wire agents into CI/CD and run headless reviews",
+            "M5 (Take-home): Build todd into a Claude Code clone",
         ],
         notes="Frame this as a hands-on journey. Where we'll progressively build up capabilities and complexity. Transition: Let's start with what Claude Code actually is.",
     ),

--- a/modules/module1.md
+++ b/modules/module1.md
@@ -134,6 +134,9 @@ In the chat box, run:
 > There are many other built-in slash commands you can see if you just type `/` in the chat window.
 > For a full list, see the [Anthropic docs on slash commands](https://code.claude.com/docs/en/interactive-mode#built-in-commands).
 
+> **Pro tip:** Type `/cost` to see token usage and spend for this session, or
+> `/stats` for daily patterns. Cost awareness grows more important in later modules.
+
 ---
 
 ## 6. CLI Navigation Essentials
@@ -150,6 +153,9 @@ this in step 3). It's shorthand for asking Claude to run a Bash tool call.
 a new line in the prompt.
 
 **`Ctrl+G`** — open the current prompt in your default text editor for longer edits.
+
+**`Esc+Esc`** — open the rewind menu to undo Claude's changes (code, conversation,
+or both). Useful when Claude goes in a wrong direction.
 
 > **Exercise:** Type `@src/todd/__init__.py` to reference the init file, then run
 > `!uv run todd hello` to verify the CLI still works.


### PR DESCRIPTION
Adds Esc+Esc shortcut and /cost pro tip to module 1. Updates slide 4 to frame M5 as a take-home capstone project.

## Changes
- **Section 6**: Added Esc+Esc shortcut documentation for rewind menu
- **Section 5**: Added /cost pro tip for cost awareness
- **Slide 4**: Updated M5 bullet to frame it as a take-home capstone project

## Verification
- ✓ generate_slides.py runs successfully
- ✓ Generated 37 slides without errors