### PR TITLE
feat(module5): rewrite as take-home capstone project with 5 milestone PRDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ The tools we build can be the building blocks to take into your own projects or 
 As we progress through the course we will use the `/module` command in Claude to migrate our application into a more heavily structured agentic codebase.
 This will allow us to slowly introduce topics and focus on key aspects of the tool and agentic coding as we progress.
 
+## Workshop Structure
+
+| Module | Focus | Format | Est. Time |
+|--------|-------|--------|-----------|
+| 1 | Project Scaffolding | In-person | ~20 min |
+| 2 | MCP, Plan Mode, Agent SDK | In-person | ~35 min |
+| 3 | Commands, Skills, Hooks | In-person | ~40 min |
+| 4 | Team Orchestration | In-person | ~55 min |
+| 5 | Build a Claude Code Clone | Take-home project | 2-4 hours |
 
 ## How Modules Work
 

--- a/docs/prds/todd-context.md
+++ b/docs/prds/todd-context.md
@@ -1,0 +1,59 @@
+# PRD: todd CLAUDE.md Loading
+
+## Overview
+
+Auto-discover and load CLAUDE.md context files as the system prompt, so todd
+behaves consistently with project-specific conventions — the same way Claude Code
+reads CLAUDE.md on startup.
+
+## Usage
+
+Given a `CLAUDE.md` in the project root:
+```markdown
+## Project
+todd is a Typer CLI built with Python 3.13+ and uv.
+Always use type annotations. Run tests with `uv run pytest`.
+```
+
+```shell
+uv run todd
+todd> what's the test command for this project?
+Based on the project context, the test command is `uv run pytest`.
+```
+
+## Requirements
+
+### Functional
+
+- On startup, search for CLAUDE.md files in this order:
+  1. `~/.claude/CLAUDE.md` (global user config)
+  2. `~/.claude/CLAUDE.md.local` (global personal overrides)
+  3. `./CLAUDE.md` (project root)
+  4. `./.claude/CLAUDE.md.local` (project personal overrides)
+- Load all discovered files and concatenate their contents
+- Pass the combined content as the system prompt to the SDK
+- Support `@<filepath>` import syntax: if a CLAUDE.md line starts with `@`,
+  read the referenced file and inline its contents
+- If no CLAUDE.md files are found, proceed without a system prompt (no error)
+
+### Non-Functional
+
+- File discovery is silent — no output when loading context
+- Invalid `@file` references are skipped with a warning to stderr
+- Maximum total system prompt size: 100KB (truncate with a warning if exceeded)
+
+## Dependencies
+
+No new dependencies beyond `claude-agent-sdk>=0.1.0`.
+
+## Implementation Notes
+
+- Discovery order matters: later files can override earlier ones
+- The `@` import is a simple text substitution before passing to the SDK
+- Relative paths in `@` imports resolve from the CLAUDE.md file's directory
+
+## Out of Scope
+
+- `@url` imports
+- `@agent` scoped rules
+- Hot-reloading CLAUDE.md during a session

--- a/docs/prds/todd-repl.md
+++ b/docs/prds/todd-repl.md
@@ -1,0 +1,61 @@
+# PRD: todd Interactive REPL
+
+## Overview
+
+Replace todd's single-shot query with an interactive terminal loop. After this
+milestone, `uv run todd` opens a persistent session where users can send multiple
+prompts to Claude and see responses — like a minimal Claude Code terminal.
+
+## Usage
+
+```shell
+uv run todd
+```
+
+Expected session:
+```
+todd> what model are you running?
+I'm running claude-sonnet-4-6.
+
+todd> how many tokens was that?
+That response used approximately 12 tokens.
+
+todd> /exit
+Bye.
+```
+
+## Requirements
+
+### Functional
+
+- Entering `uv run todd` (no positional argument) starts the REPL loop
+- The loop reads a line of input, sends it to Claude, prints the response, repeats
+- Conversation history accumulates across turns (each prompt/response pair added to messages)
+- `/exit` or `/quit` typed at the prompt ends the session gracefully
+- `Ctrl+C` ends the session gracefully (no traceback)
+- The prompt prefix is `todd> `
+
+### Non-Functional
+
+- Existing `uv run todd "prompt"` single-shot mode must continue to work
+- No streaming — print the complete response once available (streaming is Milestone 3)
+- Authentication uses Amazon Bedrock (`CLAUDE_CODE_USE_BEDROCK=1`) with standard AWS credential chain
+
+## Dependencies
+
+No new dependencies beyond Milestone 0 (`claude-agent-sdk>=0.1.0`).
+
+## Implementation Notes
+
+- Use a `while True` loop with `input("todd> ")` to read prompts
+- Maintain a `messages: list` that grows with each turn
+- Pass the full message history to the SDK on each call
+- Catch `KeyboardInterrupt` to handle Ctrl+C gracefully
+- Check for `/exit` or `/quit` before sending to the SDK
+
+## Out of Scope
+
+- Streaming output (Milestone 3)
+- Tool use (Milestone 2)
+- Session persistence (Milestone 5)
+- CLAUDE.md loading (Milestone 4)

--- a/docs/prds/todd-sessions.md
+++ b/docs/prds/todd-sessions.md
@@ -1,0 +1,61 @@
+# PRD: todd Session Persistence
+
+## Overview
+
+Save conversation history to disk so sessions can be resumed across terminal
+restarts — mirroring the `claude --continue` and `claude --resume` behavior
+that participants learned in Module 2.
+
+## Usage
+
+```shell
+# Name the session and exit
+uv run todd
+todd> /rename todd-refactor
+todd> /exit
+
+# Resume later
+uv run todd --resume todd-refactor
+todd> where were we?
+[Claude has full context of the previous conversation]
+
+# Or resume the most recent session
+uv run todd --continue
+```
+
+## Requirements
+
+### Functional
+
+- On `/exit` or `Ctrl+C`, save the conversation history to disk
+- Sessions are stored as JSON files in `~/.todd/sessions/<session-id>.json`
+- Each session file contains: session ID, name, timestamp, message history
+- `/rename <name>` sets a human-readable name for the current session
+- `todd --continue` resumes the most recent session by modification time
+- `todd --resume <name>` resumes a session by name (substring match)
+- `todd --resume` with no argument lists available sessions and prompts for choice
+- `/sessions` in the REPL lists available sessions
+
+### Non-Functional
+
+- Session files are human-readable JSON
+- A new session is created if no matching session is found for `--resume`
+- Session IDs are 8-character hex strings (same pattern as ADW IDs)
+
+## Dependencies
+
+No new dependencies beyond `claude-agent-sdk>=0.1.0`.
+
+## Implementation Notes
+
+- Create `~/.todd/sessions/` on first run if it doesn't exist
+- Session ID is generated with `secrets.token_hex(4)`
+- The message history stored is the same list passed to the SDK — portable JSON
+- On resume, load messages and pass as initial history to the SDK loop
+
+## Out of Scope
+
+- Session encryption or access control
+- Cloud sync or backup
+- Session branching (multiple paths from one checkpoint)
+- `/export` command (can be added later)

--- a/docs/prds/todd-streaming.md
+++ b/docs/prds/todd-streaming.md
@@ -1,0 +1,50 @@
+# PRD: todd Streaming Output
+
+## Overview
+
+Show Claude's output token-by-token as it generates, rather than waiting for the
+complete response. After this milestone, todd feels responsive — users see progress
+immediately instead of waiting for a full response before anything appears.
+
+## Usage
+
+```shell
+uv run todd
+todd> explain how the ADW works
+Explaining the ADW...
+[text appears progressively as Claude generates it]
+```
+
+## Requirements
+
+### Functional
+
+- Text responses stream to the terminal as tokens arrive
+- Tool calls display inline as they start and complete:
+  - `[read src/todd/cli.py]` when the Read tool is called
+  - `[read complete: 42 lines]` when it returns
+- `Ctrl+C` during generation stops the stream gracefully (no traceback, prompt returns)
+- After the stream completes, a newline is printed before the next `todd> ` prompt
+
+### Non-Functional
+
+- Streaming requires the SDK's stream event API (not the query function)
+- Single-shot mode (`uv run todd "prompt"`) also streams
+
+## Dependencies
+
+No new dependencies beyond `claude-agent-sdk>=0.1.0`.
+
+## Implementation Notes
+
+- Switch from the `query()` function to the SDK's streaming interface
+- Handle `text_delta` events by writing to stdout without newlines
+- Handle `tool_use` events by displaying the tool name and input
+- Handle `tool_result` events by displaying the result summary
+- Flush stdout after each write to ensure tokens appear immediately
+- Catch `KeyboardInterrupt` to stop streaming and return to the prompt
+
+## Out of Scope
+
+- Rich terminal formatting (colors, spinners, progress bars)
+- Streaming to a file or other output targets

--- a/docs/prds/todd-tools.md
+++ b/docs/prds/todd-tools.md
@@ -1,0 +1,53 @@
+# PRD: todd Tool Use
+
+## Overview
+
+Register filesystem and shell tools with the Agent SDK so todd can act on the
+codebase — reading files, writing code, running commands. After this milestone,
+todd functions as a basic agentic coding tool.
+
+## Usage
+
+```shell
+uv run todd
+todd> read src/todd/cli.py and tell me what it does
+[Claude reads the file and explains it]
+
+todd> add a hello command to the CLI
+[Claude reads, edits, and verifies the change]
+```
+
+## Requirements
+
+### Functional
+
+- Register these tools with the SDK: `Read`, `Write`, `Edit`, `Bash`, `Glob`, `Grep`
+- Tool calls are executed automatically during the agent loop
+- Tool results (file contents, command output) are passed back to Claude
+- For destructive operations (`Write`, `Edit`, `Bash`), display what will happen and
+  prompt the user for confirmation before executing
+- Tool call display: show the tool name and key argument before executing
+
+### Non-Functional
+
+- Confirmation prompt must be skippable via a `--yes` / `-y` flag on the CLI
+- Existing single-shot mode (`uv run todd "prompt"`) also gets tool support
+- Authentication uses Amazon Bedrock (`CLAUDE_CODE_USE_BEDROCK=1`)
+
+## Dependencies
+
+No new dependencies beyond `claude-agent-sdk>=0.1.0`.
+
+## Implementation Notes
+
+- The SDK's `allowed_tools` parameter controls which tools are available
+- Each tool is a callable that the SDK invokes automatically when Claude requests it
+- Wrap each tool call in a confirmation prompt for destructive operations
+- The `Bash` tool is the highest-risk tool — limit to a reasonable set of safe commands
+  or always require confirmation
+
+## Out of Scope
+
+- Custom tool definitions beyond the standard set
+- Sandboxing (filesystem isolation)
+- Permission levels or role-based tool access

--- a/modules/module5.md
+++ b/modules/module5.md
@@ -1,293 +1,110 @@
-# Module 5: Operations & Maintenance
+# Module 5: Build a Claude Code Clone (Take-Home Project)
 
-This module covers operational skills for sustained Claude Code usage — running
-Claude headlessly in scripts and CI, managing sessions and costs, and maintaining
-the CLAUDE.md that shapes everything.
+This module is a self-paced capstone project. You'll extend todd from a
+single-shot prompt forwarder into an interactive agentic tool — a miniature
+Claude Code clone.
 
----
+**Use your ADW tools.** The commands, agents, and orchestrators you built in
+Modules 3-4 are designed for exactly this kind of work. Try running
+`/feature` or `/team:feature` against the PRDs below to let Claude drive
+the implementation.
 
-## Key Concepts
-
-| Term | Definition |
-|------|-----------|
-| **Headless mode** | Running Claude non-interactively with `claude -p "prompt"`. Outputs text, JSON, or streaming JSON. Used in scripts, CI pipelines, and batch operations. |
-| **Session persistence** | Claude Code saves all sessions locally. Resume with `--continue` (most recent) or `--resume` (pick by ID/name). |
-| **Effort level** | Controls how much reasoning Claude applies. Low/medium/high. Affects cost and quality. Set via `/model`. |
-| **Checkpointing** | Automatic snapshots before every Claude action. Rewind with `Esc+Esc` or `/rewind` to undo changes without losing the session. |
+**Estimated time:** 2-4 hours across multiple sessions. Use `claude --resume`
+to pick up where you left off.
 
 ---
 
-## Tools in this module
+## Where Todd Stands
 
-**Built-in tools**
+After Module 4, todd can:
+- `uv run todd "prompt"` — send one prompt to Claude via the Agent SDK, print the response
+- No conversation history, no tool use, no streaming, no CLAUDE.md loading
 
-| Tool | What it does |
-|------|-------------|
-| `Read` | Reads a file from the filesystem |
-| `Write` | Creates a new file |
-| `Edit` | Makes targeted edits to an existing file |
-| `Bash` | Runs a shell command |
-| `Glob` | Finds files by pattern (e.g. `**/*.py`) |
-| `Grep` | Searches file contents by regex |
-| `Task` | Spawns a specialist subagent for focused work |
+## The Goal
+
+Build these capabilities incrementally. Each milestone has a PRD in `docs/prds/`
+that defines the feature. Work through them in order — each builds on the last.
 
 ---
 
-## 1. Headless Mode & Scripting
+## Milestone 1: Interactive REPL
 
-Headless mode runs Claude non-interactively — no chat box, no confirmation prompts.
-The command runs, produces output, and exits.
+**PRD:** `docs/prds/todd-repl.md`
 
-**Basic usage:**
-
-```shell
-claude -p "explain the main function in src/todd/cli.py"
-```
-
-**Output formats:**
-
-| Flag | Output | Use case |
-|------|--------|----------|
-| `--output-format text` | Plain text (default) | Human-readable output |
-| `--output-format json` | Full conversation JSON | Structured parsing |
-| `--output-format stream-json` | Real-time JSON events | Live progress monitoring |
-
-**Control flags:**
-
-| Flag | Purpose |
-|------|---------|
-| `--max-turns N` | Limit agentic turns |
-| `--max-budget-usd X.XX` | Hard cost cap |
-| `--allowedTools "Read,Grep"` | Restrict available tools |
-
-**Piping content:**
-
-```shell
-cat src/todd/query.py | claude -p "review this code for type annotation completeness"
-```
-
-**Structured output** — use `--json-schema` to get validated JSON responses matching
-a schema you define.
-
-> **Exercise:** Write a 3-line shell script that runs `claude -p` on each `.py` file
-> in `src/todd/` to check for type annotation completeness:
->
-> ```shell
-> #!/bin/bash
-> for f in src/todd/*.py; do
->   claude -p "Check if all functions in this file have complete type annotations" < "$f"
-> done
-> ```
+Replace the single-shot query with an interactive terminal loop:
+- Read-eval-print loop with prompt handling
+- Conversation history (accumulating messages across turns)
+- Graceful exit (Ctrl+C, /exit)
+- Session display (show Claude's responses as they complete)
 
 ---
 
-## 2. CI/CD Integration
+## Milestone 2: Tool Use
 
-Headless mode is what makes Claude useful in pipelines. The pattern is simple:
-feed context in, get analysis out, gate on the result.
+**PRD:** `docs/prds/todd-tools.md`
 
-**PR review bot** — run Claude on a diff:
-
-```shell
-gh pr diff 42 | claude -p "Review this diff for bugs, style issues, and missing tests"
-```
-
-**Automated analysis on push** — add to any CI pipeline:
-
-```shell
-claude -p "Analyze src/ for security vulnerabilities" --max-turns 5 --max-budget-usd 0.50
-```
-
-**Sample GitHub Actions workflow:**
-
-```yaml
-name: Claude Code Review
-on: [pull_request]
-
-jobs:
-  review:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run Claude review
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: |
-          gh pr diff ${{ github.event.number }} | \
-            claude -p "Review this PR diff. Report any bugs, security issues, or style violations." \
-            --output-format json \
-            --max-turns 5 \
-            --dangerously-skip-permissions
-```
-
-**`--dangerously-skip-permissions`** — this flag disables all confirmation prompts.
-It's named that way intentionally: in CI there's no human to confirm, but you're also
-removing a safety layer. Only use it in controlled environments with restricted tool
-access.
-
-> **Callout:** CI integration is where headless mode and CLAUDE.md converge — the
-> agent runs autonomously, shaped only by configuration. The CLAUDE.md you maintain
-> is the only instruction set the CI agent receives.
+Register tools with the Agent SDK so todd can act on the filesystem:
+- Read, Write, Edit — file operations
+- Bash — shell command execution
+- Glob, Grep — search operations
+- Permission prompts before destructive operations
 
 ---
 
-## 3. Session Management
+## Milestone 3: Streaming Output
 
-Claude Code saves every session locally. You can resume, rename, and export them.
+**PRD:** `docs/prds/todd-streaming.md`
 
-| Command / Flag | What it does |
-|---------------|-------------|
-| `claude --continue` (`-c`) | Resume the most recent session |
-| `claude --resume` (`-r`) | Pick from a session list by ID or name |
-| `/rename <name>` | Give the current session a descriptive name |
-| `/export [filename]` | Save conversation to a file |
-
-**Named sessions** make it easy to return to specific work:
-
-```shell
-# Name the session while working
-/rename todd-query-refactor
-
-# Later, resume by name
-claude --resume todd-query-refactor
-```
-
-**`--from-pr <number>`** — start or resume a session linked to a specific pull request.
-Claude loads the PR context automatically.
-
-> **Exercise:** `/rename` the current session to something descriptive, then exit with
-> `/exit`. Resume it with `claude --resume` and verify your conversation history is
-> intact.
+Show Claude's output token-by-token as it generates:
+- Stream text responses to the terminal
+- Display tool calls and their results inline
+- Handle interrupts (Ctrl+C to stop generation)
 
 ---
 
-## 4. Cost & Extended Thinking
+## Milestone 4: CLAUDE.md Loading
 
-Understanding cost helps you choose the right model and effort level for each task.
+**PRD:** `docs/prds/todd-context.md`
 
-**Session cost tracking:**
-
-| Command | What it shows |
-|---------|-------------|
-| `/cost` | Token usage and pricing for this session |
-| `/stats` | Daily usage patterns and session history |
-
-**Model cost tiers:**
-
-| Model | Relative cost | Best for |
-|-------|--------------|----------|
-| Haiku | Lowest | Exploration, simple searches, code review |
-| Sonnet | Medium | Code generation, implementation, most tasks |
-| Opus | Highest | Architecture decisions, complex reasoning, planning |
-
-**Effort levels** — accessible via `/model`, then select effort:
-
-| Level | Behavior | Use case |
-|-------|----------|----------|
-| Low | Minimal reasoning | Simple edits, typo fixes |
-| Medium | Balanced (default) | Most development tasks |
-| High | Maximum reasoning | Architecture, complex debugging |
-
-**Extended thinking** — `Alt+T` toggles extended thinking, which gives Claude a
-scratchpad for longer reasoning chains. `Ctrl+O` shows the thinking process in
-verbose mode.
-
-When extended thinking matters: complex debugging where the root cause isn't obvious,
-architecture decisions with multiple trade-offs, multi-step reasoning across many files.
-
-> **Exercise:** Run `/cost` to see your current session usage. Then switch effort levels
-> via `/model` and compare the cost difference on a simple task.
+Discover and load context engineering files:
+- Auto-discover CLAUDE.md (project root, user home, .claude/ directory)
+- Load as system prompt content
+- Support @file import syntax
 
 ---
 
-## 5. Checkpointing & Recovery
+## Milestone 5: Session Persistence
 
-Claude Code automatically snapshots your codebase before every action. If something
-goes wrong, you can rewind without losing your session.
+**PRD:** `docs/prds/todd-sessions.md`
 
-**`Esc+Esc`** — open the rewind menu. Choose to restore:
-- **Code only** — revert file changes, keep the conversation
-- **Conversation only** — roll back context, keep file changes
-- **Both** — full restore to a previous point
-
-**`/rewind`** — same menu, accessed from the command line.
-
-**When to use checkpointing:**
-- Undo a bad implementation without starting over
-- Recover from context poisoning (bad info entered the conversation)
-- Try alternative approaches from the same starting point
-
-> **Exercise:** Make an intentional bad change (e.g., delete a function), then press
-> `Esc+Esc` to open the rewind menu and restore the code. Notice that your conversation
-> history is preserved — you didn't lose the session.
-
-**Limitation:** Checkpointing only tracks changes made by Claude. External processes
-(manual edits, other tools) aren't captured in the rewind history.
+Save and resume conversations:
+- Serialize conversation history to disk
+- `todd --continue` (most recent) and `todd --resume` (by name)
+- `/rename` for session naming
 
 ---
 
-## 6. CLAUDE.md Maintenance
+## Operational Reference
 
-A CLAUDE.md that drifts out of date is worse than no CLAUDE.md — it actively misleads
-Claude with stale instructions.
+As you build, these operational skills will be useful:
 
-**Anti-patterns to avoid:**
-
-| Anti-pattern | Problem |
-|-------------|---------|
-| Too long (>200 lines) | Noise drowns out signal; Claude gives less weight to each instruction |
-| Contradictory instructions | Claude picks one arbitrarily; behavior becomes unpredictable |
-| Stale file references | Claude tries to read files that no longer exist |
-| Vague directives ("be careful") | No actionable constraint; Claude ignores them |
-
-**Audit checklist** — run through this periodically:
-
-- [ ] Are all referenced files still present?
-- [ ] Are tool and command names current?
-- [ ] Are there conflicting instructions?
-- [ ] Is the tech stack accurate?
-- [ ] Are test commands still correct?
-- [ ] Do coding standards match what's actually enforced?
-
-**Evolution pattern:** After each significant project change — new dependency, refactored
-module, changed conventions — review the CLAUDE.md for staleness. Treat it like any
-other config file: it needs maintenance.
-
-> **Exercise:** Audit the workshop's CLAUDE.md. After four modules of work, identify
-> anything that's become stale or could be improved. Check file references, command
-> names, and tech stack accuracy.
-
-> **Callout:** A well-maintained CLAUDE.md is worth more than any amount of prompt
-> engineering in individual conversations. It's the compound interest of AI-assisted
-> development — small investments in accuracy pay off across every session.
+| Skill | How | When |
+|-------|-----|------|
+| Cost tracking | `/cost`, `/stats` | Monitor spend per session |
+| Effort levels | `/model` → low/medium/high | Balance cost vs quality |
+| Extended thinking | `Alt+T` | Complex reasoning tasks |
+| Checkpointing | `Esc+Esc`, `/rewind` | Recover from wrong directions |
+| Headless testing | `claude -p "prompt"` | Test todd features non-interactively |
+| CI/CD patterns | `gh pr diff \| claude -p "review"` | Automate reviews in pipelines |
 
 ---
 
-## 7. Further Reading
+## Further Reading
 
-These features extend Claude Code beyond what we've covered in the workshop.
-
-**IDE integrations** — Claude Code works inside your editor:
-- VS Code: install the "Claude Code" extension from the Extensions marketplace
-- JetBrains: install the Claude Code plugin
-- Both provide inline diffs, file references, and plan review within the editor
-
-**Plugins** — `/plugin` to browse the marketplace. Plugins bundle skills, hooks, agents,
-and MCP servers into installable packages. You installed Context7 (Module 2) and
-document-skills (Module 3) this way.
-
-**Sandbox configuration** — OS-level filesystem and network isolation for autonomous
-agent work. Configure in `settings.json` under `"sandbox"`. Useful when running agents
-with `bypassPermissions` on untrusted input.
-
-**Browser automation** — `claude --chrome` for web testing, Playwright MCP for
-automated UI interaction. Useful for end-to-end testing and visual verification.
-
-**Desktop app & cloud** — `claude.ai/code` for browser-based Claude Code, `/desktop`
-to hand off sessions between terminal and desktop.
-
-> **Callout:** These features extend Claude Code beyond the terminal. Explore them as
-> your workflow matures.
+- [Claude Code docs](https://code.claude.com/docs/en) — the product you're cloning
+- [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk) — the library powering todd
+- IDE integrations: VS Code extension, JetBrains plugin
+- Plugins: `/plugin` marketplace for shared skills
 
 ---
 


### PR DESCRIPTION
## Summary

Full rewrite of module5.md as a self-paced capstone project guide with 5 milestones (REPL, tools, streaming, CLAUDE.md loading, sessions).

## Changes

- **modules/module5.md** - Complete rewrite as capstone project guide
  - Where Todd Stands section
  - 5 milestone descriptions with PRD references
  - Operational reference table
  - Further reading section

- **docs/prds/** - 5 new PRD files following todd-query.md pattern:
  - `todd-repl.md` - Interactive REPL milestone
  - `todd-tools.md` - Tool use milestone
  - `todd-streaming.md` - Streaming output milestone
  - `todd-context.md` - CLAUDE.md loading milestone
  - `todd-sessions.md` - Session persistence milestone

- **README.md** - Added workshop structure table showing all 5 modules with format and time estimates

- **.claude/claude.local.md** - Updated module trajectory table to include Module 5 take-home project

## Migration Strategy

Learners will use their ADW tools built in Modules 3-4 to implement the PRDs. Each milestone builds incrementally on the previous.