### PR TITLE
Propagate module-4 into module-5

### DIFF
--- a/docs/prds/adw-commands.md
+++ b/docs/prds/adw-commands.md
@@ -73,6 +73,8 @@ research + plan + validation (parallel) → implement + review + document
 
 - Each command lives at `.claude/commands/<name>.md`
 - All commands accept `$ARGUMENTS` (description or `@file` PRD reference)
+- Commands MUST NOT set `context: fork` in frontmatter — all four commands
+  run in the primary context so team activity remains visible to the user
 - Single-agent commands execute phases sequentially with context handoff
 - Team commands use `TeamCreate` for setup, `TaskCreate` for work items,
   `SendMessage` for coordination

--- a/modules/module4.md
+++ b/modules/module4.md
@@ -374,9 +374,10 @@ Merge the worktree changes and commit the orchestrator scripts
 
 **Take it home.** Module 5 is a capstone project: extend todd from a single-shot
 CLI into a Claude Code clone with interactive chat, tool use, and session management.
-Use the ADW commands you built in Module 3 to drive the development. Open
-[modules/module5.md](module5.md) when you're ready.
+Use the ADW commands you built in Module 3 to drive the development.
+
+Run `/module` to switch to the module-5 branch and open the capstone instructions.
 
 ---
 
-[← Module 3](module3.md) | [Module 5 (Take-home) →](module5.md)
+[← Module 3](module3.md)


### PR DESCRIPTION
Automated forward-merge of module-4 changes via /propagate. Resolved 1 conflict: kept modules/module5.md (deleted in module-4 as stale, but belongs in module-5).