### PR TITLE
docs(module4): fix filenames, add skills frontmatter and memory tip

### DIFF
--- a/modules/module1.md
+++ b/modules/module1.md
@@ -99,7 +99,10 @@ project instructions that load automatically every session.
 |-------|------|----------------|
 | Global (all projects) | `~/.claude/CLAUDE.md` | No |
 | Project (team-wide) | `./CLAUDE.md` | Yes |
-| Personal (local only) | `./CLAUDE.md.local` | No (gitignored) |
+| Personal (local only) | `./CLAUDE.local.md` | No (gitignored) |
+
+> Project memory can also live at `./.claude/CLAUDE.md`. When scopes overlap,
+> project-level instructions take precedence over global.
 
 **Exercise:** Update the project `CLAUDE.md` with proper structure:
 
@@ -155,7 +158,8 @@ a new line in the prompt.
 **`Ctrl+G`** — open the current prompt in your default text editor for longer edits.
 
 **`Esc+Esc`** — open the rewind menu to undo Claude's changes (code, conversation,
-or both). Useful when Claude goes in a wrong direction.
+or both). Useful when Claude goes in a wrong direction. Note: only tracks file edits
+via Write/Edit tools, not changes made by bash commands.
 
 > **Exercise:** Type `@src/todd/__init__.py` to reference the init file, then run
 > `!uv run todd hello` to verify the CLI still works.

--- a/modules/module3.md
+++ b/modules/module3.md
@@ -113,6 +113,13 @@ The distinction in practice:
 | **Use case** | Phase execution, defined workflows | Standards, guidelines, domain knowledge |
 | **Location** | `.claude/commands/<name>.md` | `.claude/skills/<name>/SKILL.md` |
 | **Good for** | "Do this specific thing" | "Know this when doing related things" |
+| **Frontmatter** | N/A (just markdown) | `disable-model-invocation`, `context: fork`, `allowed-tools` |
+
+> **Skills can behave exactly like commands.** Set `disable-model-invocation: true`
+> in a skill's frontmatter to prevent auto-loading — it will only run when the user
+> invokes it via `/skill-name`. Add `context: fork` to run it in an isolated subagent
+> (useful for workflows that shouldn't pollute the main context). This gives you
+> command-style explicit invocation with skill-level bundled references and scripts.
 
 > **Four ways to deliver work.** The phase commands are reusable primitives.
 > You can compose them in four ways — two single-agent, two multi-agent:
@@ -357,6 +364,10 @@ moments to inject or capture context dynamically.
 You've now seen CLAUDE.md as project-level configuration. It's also a powerful context
 engineering tool with several advanced features.
 
+> **Tip:** Use `/memory` to see all loaded memory files and their sources. Auto-memory
+> (`~/.claude/projects/<project>/memory/`) stores Claude's learnings across sessions —
+> the first 200 lines of `MEMORY.md` load automatically at startup.
+
 **Import syntax** — use `@path/to/file` inside CLAUDE.md to pull in content from other
 files. This lets you maintain shared rules, tech stack details, or architecture decisions
 in separate files while keeping CLAUDE.md as the entry point.
@@ -383,7 +394,7 @@ fire when Claude is editing test files.
 | `.claude/rules/tests.md` | Files under `tests/` |
 | `.claude/rules/docs.md` | Files under `docs/` |
 
-**`.claude/CLAUDE.md.local`** — personal overrides not committed to git. Use for
+**`CLAUDE.local.md`** — personal overrides not committed to git. Use for
 individual editor preferences, personal workflow notes, or debugging flags that
 shouldn't affect teammates.
 
@@ -392,7 +403,7 @@ affect the team configuration.
 
 **Team conventions** — the project CLAUDE.md serves as a team contract. Shared standards
 (tech stack, commit conventions, code style) go in the committed CLAUDE.md. Personal
-preferences (verbosity, editor, shortcuts) go in `.claude/CLAUDE.md.local`.
+preferences (verbosity, editor, shortcuts) go in `CLAUDE.local.md`.
 
 > **Exercise:**
 > 1. Create `.claude/rules/src.md` with a rule about error handling for `src/`
@@ -401,7 +412,7 @@ preferences (verbosity, editor, shortcuts) go in `.claude/CLAUDE.md.local`.
 >    established in existing modules.")
 > 2. Add an `@docs/adr/adw.md` import to the project CLAUDE.md so Claude always has the
 >    ADW architecture reference
-> 3. Create a `.claude/CLAUDE.md.local` with a personal preference (e.g., preferred
+> 3. Create a `CLAUDE.local.md` with a personal preference (e.g., preferred
 >    verbosity level or a debugging note)
 
 > **Callout:** CLAUDE.md, skills, hooks, and `rules/` form a four-layer context system.


### PR DESCRIPTION
## Summary

Propagates all doc fixes to the module-4 branch so participants on this branch see accurate docs across all modules covered so far.

- Corrects `CLAUDE.md.local` → `CLAUDE.local.md` in module1.md and module3.md
- Adds rewind caveat (Write/Edit tools only, not bash) to module1.md
- Adds scope precedence note to module1.md
- Adds `Frontmatter` row and callout to skills/commands table in module3.md
- Adds `/memory` tip to CLAUDE.md context engineering section in module3.md