### PR TITLE
docs(module2): add lethal trifecta security callout

### DIFF
--- a/modules/module2.md
+++ b/modules/module2.md
@@ -77,6 +77,17 @@ Browse to the **Discover** tab, find **context7**, and install it at **user** sc
 >
 > Think of it like npm or pip, but for Claude Code capabilities.
 
+> **Security: the lethal trifecta.** Simon Willison
+> [identifies three capabilities](https://simonwillison.net/2025/Jun/16/the-lethal-trifecta/)
+> that, combined in an AI agent, create serious security risk:
+> **(1)** access to private data, **(2)** exposure to untrusted content, and
+> **(3)** the ability to communicate externally. An MCP server can grant all
+> three — file-system tools read private data, web-fetching tools ingest
+> untrusted content, and API tools can send data out. Claude Code's permission
+> prompts are your first line of defense, but they're not a substitute for
+> reviewing what tools a plugin actually installs. Before you approve, check
+> the tool list and understand what each one does.
+
 ---
 
 ## 2. Examine Context Utilization


### PR DESCRIPTION
Adds a security awareness callout after the plugin/marketplace introduction in Module 2.

References Simon Willison's [lethal trifecta](https://simonwillison.net/2025/Jun/16/the-lethal-trifecta/) — the three capabilities (private data access, untrusted content exposure, external communication) that, combined, create serious security risk in AI agents. This is the right moment to surface it since participants have just installed their first MCP server.