### PR TITLE
docs(setup): add pre-workshop prerequisites section

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -1,5 +1,16 @@
 # AWS Bedrock configuration
 
+## Before You Begin
+
+- **IDE** — You'll need a code editor. **VS Code** is recommended (free, cross-platform, excellent terminal integration). Any editor with an integrated terminal works.
+- **Run `claude update`** — ensure Claude Code is on the latest version before starting.
+- **Clone outside OneDrive/iCloud** — synced folders cause file-locking issues with git and uv; clone to a local-only directory (e.g. `~/repos/`).
+- **Quick clone instructions**:
+  ```
+  git clone https://github.com/shiftysheep/cc-workshop.git
+  cd cc-workshop
+  ```
+
 ## Automated Setup (Recommended)
 
 Run the automated configuration script:


### PR DESCRIPTION
## Summary

- Adds a new "Before You Begin" section before the Automated Setup instructions
- Covers: VS Code recommendation, `claude update`, OneDrive/iCloud clone warning, quick clone instructions

Closes #58