### PR TITLE
docs(module3): rename title to Extending Claude Code

### DIFF
--- a/modules/module3.md
+++ b/modules/module3.md
@@ -1,4 +1,4 @@
-# Module 3: ADW Foundations — Commands, Skills, and Hooks
+# Module 3: Extending Claude Code — Commands, Skills, Hooks, and Agents
 
 In this module we use Claude to generate a visual reference document for the ADW
 system already present in this branch, then explore the `.claude/` scaffolding that


### PR DESCRIPTION
## Summary
- Replace "ADW Foundations — Commands, Skills, and Hooks" with "Extending Claude Code — Commands, Skills, Hooks, and Agents"
- Removes unexplained "ADW Foundations" jargon from the section heading
- Describes what participants actually build in the module

## Test plan
- [ ] `modules/module3.md` H1 matches canonical title
- [ ] No stale "ADW Foundations" in any title/heading