### PR TITLE
docs: align module titles across module files and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ This will allow us to slowly introduce topics and focus on key aspects of the to
 | Module | Focus | Format | Est. Time |
 |--------|-------|--------|-----------|
 | 1 | Project Scaffolding | In-person | ~30 min |
-| 2 | MCP, Plan Mode, Agent SDK | In-person | ~40 min |
-| 3 | Commands, Skills, Hooks | In-person | ~40 min |
+| 2 | MCP, Plan Mode, and the Agent SDK | In-person | ~40 min |
+| 3 | Extending Claude Code | In-person | ~40 min |
 | 4 | Building Orchestration Commands | In-person | ~25 min |
 | 5 | Team Orchestration | In-person | ~55 min |
 | 6 | Build a Claude Code Clone | Take-home project | 2-4 hours |

--- a/modules/module2.md
+++ b/modules/module2.md
@@ -1,4 +1,4 @@
-# Module 2: MCP, Plan Mode, and the Claude Agent SDK
+# Module 2: MCP, Plan Mode, and the Agent SDK
 
 In this module we'll install our first MCP server, explore how tools load on demand via ToolSearch,
 switch to a more capable model for planning, and build a real feature using the

--- a/modules/module5.md
+++ b/modules/module5.md
@@ -1,4 +1,4 @@
-# Module 5: Agentic Delivery Workflows
+# Module 5: Team Orchestration
 
 In this module you use the orchestration commands from Module 4 to build
 Python orchestrators in parallel worktrees. Two Claude instances run


### PR DESCRIPTION
## Summary
- `modules/module2.md` H1: drop "Claude" from "MCP, Plan Mode, and the Claude Agent SDK"
- `modules/module5.md` H1: "Agentic Delivery Workflows" → "Team Orchestration" (matches slides/README)
- `README.md` Workshop Structure: rows 2 and 3 now match canonical module file titles

## Test plan
- [ ] module2.md H1 = "Module 2: MCP, Plan Mode, and the Agent SDK"
- [ ] module5.md H1 = "Module 5: Team Orchestration"
- [ ] README row 2 Focus = "MCP, Plan Mode, and the Agent SDK"
- [ ] README row 3 Focus = "Extending Claude Code"