### PR TITLE
docs(module1): remove duplicate git clone

### DIFF
--- a/modules/module1.md
+++ b/modules/module1.md
@@ -31,13 +31,11 @@ foundation every subsequent module builds on.
 
 ---
 
-## 1. Clone and Launch
+## 1. Launch Claude
 
-Clone the repository and launch Claude from the project directory:
+Open a terminal and launch Claude from the project directory:
 
 ```shell
-git clone https://github.com/shiftysheep/cc-workshop.git
-cd cc-workshop
 claude
 ```
 


### PR DESCRIPTION
## Summary

- Replaces Step 1 "Clone and Launch" with a simpler "Launch Claude" step
- Removes `git clone` and `cd cc-workshop` commands — participants have already cloned per `SETUP.md`
- Retains the `claude` isn't found troubleshooting note

## Test plan

- [ ] `modules/module1.md` Step 1 no longer contains `git clone`
- [ ] `SETUP.md` on `main` still has the clone instructions (untouched)
- [ ] Propagation lands cleanly on all downstream branches