### PR TITLE
docs(module-1): fix Task→Agent in slides, git link, tool prompts note, PEP 723 in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,3 +11,18 @@
 ## Pre-execution Checklist
 
 Before building or running any code, verify that pre-commit hooks are configured and installed. If no `.pre-commit-config.yaml` exists, create one. Always run `uv run pre-commit install` to ensure hooks are active before the first commit.
+
+## Python One-Off Scripts
+
+For standalone scripts that don't belong to the main package, use
+[PEP 723 inline script metadata](https://peps.python.org/pep-0723/) to embed
+dependencies directly in the file:
+
+```python
+# /// script
+# requires-python = ">=3.13"
+# dependencies = ["httpx", "rich"]
+# ///
+```
+
+Run with `uv run script.py` — no venv or separate requirements file needed.

--- a/docs/generate_slides.py
+++ b/docs/generate_slides.py
@@ -161,7 +161,7 @@ SLIDES: list[SlideData] = [
             ),
             (
                 "Built-in tools: ",
-                "Read, Write, Edit, Bash, Glob, Grep, Task (subagents)",
+                "Read, Write, Edit, Bash, Glob, Grep, Agent (subagents)",
                 0,
             ),
             (

--- a/modules/module1.md
+++ b/modules/module1.md
@@ -17,7 +17,7 @@ you need to know:
 - **Push** — sends your local commits to a remote server (GitHub) so others can see them.
 
 That's enough to follow along. For a fuller primer, see GitHub's
-[About Git](https://docs.github.com/en/get-started/using-git/about-git) guide.
+[git - the simple guide](https://rogerdudler.github.io/git-guide/).
 
 ---
 
@@ -88,6 +88,11 @@ claude
 ## 2. Build the Project Scaffold
 
 In the chat box, enter:
+
+> **Approving tool calls:** As Claude works, it will pause to show you each tool call
+> and ask for approval. Review what it plans to do and press **Enter** to accept, or
+> type `no` to reject. You can also type `!` before a message to run a shell command
+> directly.
 
 ```markdown
 Let's setup our project scaffolding utilizing UV with a src layout. We will be creating a Typer cli application with the name of todd. Include a hello command. Also setup pre-commit with ruff, mypy, bandit, vulture, and xenon hooks.
@@ -224,12 +229,13 @@ Claude Code isn't just for developers. These exercises demonstrate the same agen
 capabilities applied to everyday knowledge work tasks.
 
 > **Prerequisite: Install document skills**
-> Before starting, install the skills Claude needs for file generation:
+> Before starting, add the Anthropic skills marketplace and install the document-skills plugin:
+> ```shell
+> claude plugin marketplace add anthropics/skills
+> claude plugin install document-skills@anthropic-agent-skills --scope user
 > ```
-> /install-skill document-skills:pptx
-> /install-skill document-skills:xlsx
-> ```
-> These give Claude the ability to create PowerPoint and Excel files directly.
+> This gives Claude the ability to create PowerPoint and Excel files directly.
+> Restart Claude Code after installing.
 
 ---
 


### PR DESCRIPTION
## Summary
- Fix \`Task → Agent\` tool name in generate_slides.py Slide 6
- Update git reference link to rogerdudler.github.io
- Add tool-prompts approval callout in Step 2 before scaffolding prompt
- Add PEP 723 inline script metadata section to CLAUDE.md
- Update Section 7 prerequisite to use \`claude plugin\` CLI commands

## Verification
- \`generate_slides.py\`: "Agent (subagents)" on Slide 6
- \`module1.md\` line ~20: rogerdudler URL
- \`module1.md\` Step 2: tool-prompts callout present
- \`CLAUDE.md\`: PEP 723 section with \`uv run script.py\`
- \`module1.md\` Section 7: \`claude plugin marketplace add\` + \`claude plugin install\` commands