### PR TITLE
docs(module-1): remove hello subcommand, update slide title for Strands SDK

### DIFF
--- a/docs/generate_slides.py
+++ b/docs/generate_slides.py
@@ -252,7 +252,7 @@ SLIDES: list[SlideData] = [
     ),
     # Slide 12: Module 2 Section Header
     SectionSlide(
-        title="Module 2: MCP, Plan Mode, and Agent SDK",
+        title="Module 2: MCP, Plan Mode, and the Strands Agent SDK",
         notes="Module 2 introduces the critical concept of context as a finite resource. You'll install your first MCP server, see how MCP tools load on demand via ToolSearch, switch models for planning, and build a real feature through plan mode. The key progression: Module 1 was about Claude doing things for you. Module 2 is about Claude thinking before doing. Transition: What we do in this module.",
     ),
     # Slide 13: M2 What We Do

--- a/modules/module1.md
+++ b/modules/module1.md
@@ -95,11 +95,11 @@ In the chat box, enter:
 > directly.
 
 ```markdown
-Let's setup our project scaffolding utilizing UV with a src layout. We will be creating a Typer cli application with the name of todd. Include a hello command. Also setup pre-commit with ruff, mypy, bandit, vulture, and xenon hooks.
+Let's setup our project scaffolding utilizing UV with a src layout. We will be creating a Typer cli application with the name of todd. It should be a single default command that accepts an optional positional prompt argument — running `uv run todd` with no argument prints a greeting. Also setup pre-commit with ruff, mypy, bandit, vulture, and xenon hooks.
 ```
 
 Claude will create the project structure: `pyproject.toml`, the `src/todd/` package,
-a `hello` command wired up with Typer, and code quality tooling.
+a default command wired up with Typer, and code quality tooling.
 
 > **What just happened?** Claude used `Write` and `Bash` to build the entire
 > project structure — no manual file creation needed. Claude harnessed our existing
@@ -127,10 +127,10 @@ Now install the pre-commit hooks Claude created and validate they pass:
 Test the new command directly from the chat box using the `!` prefix to run shell commands:
 
 ```shell
-!uv run todd hello
+!uv run todd
 ```
 
-You should see `Hello. How can I assist?` (or similar) printed to the terminal.
+You should see a greeting message printed to the terminal.
 
 > **Tenet 1: Verify your work.** This manual test is a spot-check — it proves
 > the CLI works *right now*. In Module 2, we'll upgrade from manual verification
@@ -219,7 +219,7 @@ or both). Useful when Claude goes in a wrong direction. Note: only tracks file e
 via Write/Edit tools, not changes made by bash commands.
 
 > **Exercise:** Type `@src/todd/__init__.py` to reference the init file, then run
-> `!uv run todd hello` to verify the CLI still works.
+> `!uv run todd` to verify the CLI still works.
 
 ---
 


### PR DESCRIPTION
## Summary
- Remove `hello` subcommand references; todd becomes a single default command
- Update slide title to reference Strands Agent SDK

## Changes
- `modules/module1.md`: 5 edits removing `hello` subcommand references
- `docs/generate_slides.py`: update Module 2 slide title