### PR TITLE
docs(module-6): migrate todd PRDs to Strands SDK, update module6 refs

### DIFF
--- a/docs/prds/todd-context.md
+++ b/docs/prds/todd-context.md
@@ -44,7 +44,7 @@ Based on the project context, the test command is `uv run pytest`.
 
 ## Dependencies
 
-No new dependencies beyond `claude-agent-sdk>=0.1.0`.
+No new dependencies beyond `strands-agents`.
 
 ## Implementation Notes
 

--- a/docs/prds/todd-repl.md
+++ b/docs/prds/todd-repl.md
@@ -43,7 +43,7 @@ Bye.
 
 ## Dependencies
 
-No new dependencies beyond Milestone 0 (`claude-agent-sdk>=0.1.0`).
+No new dependencies beyond Milestone 0 (`strands-agents`).
 
 ## Implementation Notes
 

--- a/docs/prds/todd-sessions.md
+++ b/docs/prds/todd-sessions.md
@@ -44,7 +44,7 @@ uv run todd --continue
 
 ## Dependencies
 
-No new dependencies beyond `claude-agent-sdk>=0.1.0`.
+No new dependencies beyond `strands-agents`.
 
 ## Implementation Notes
 

--- a/docs/prds/todd-streaming.md
+++ b/docs/prds/todd-streaming.md
@@ -33,7 +33,7 @@ Explaining the ADW...
 
 ## Dependencies
 
-No new dependencies beyond `claude-agent-sdk>=0.1.0`.
+No new dependencies beyond `strands-agents`.
 
 ## Implementation Notes
 

--- a/docs/prds/todd-tools.md
+++ b/docs/prds/todd-tools.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Register filesystem and shell tools with the Agent SDK so todd can act on the
+Register filesystem and shell tools with the Strands Agent SDK so todd can act on the
 codebase — reading files, writing code, running commands. After this milestone,
 todd functions as a basic agentic coding tool.
 
@@ -13,7 +13,7 @@ uv run todd
 todd> read src/todd/cli.py and tell me what it does
 [Claude reads the file and explains it]
 
-todd> add a hello command to the CLI
+todd> add a greeting to the CLI output
 [Claude reads, edits, and verifies the change]
 ```
 
@@ -36,7 +36,7 @@ todd> add a hello command to the CLI
 
 ## Dependencies
 
-No new dependencies beyond `claude-agent-sdk>=0.1.0`.
+No new dependencies beyond `strands-agents`.
 
 ## Implementation Notes
 

--- a/modules/module6.md
+++ b/modules/module6.md
@@ -17,7 +17,7 @@ to pick up where you left off.
 ## Where Todd Stands
 
 After Module 5, todd can:
-- `uv run todd "prompt"` — send one prompt to Claude via the Agent SDK, print the response
+- `uv run todd "prompt"` — send one prompt to Claude via the Strands Agent SDK, print the response
 - No conversation history, no tool use, no streaming, no CLAUDE.md loading
 
 ## The Goal
@@ -43,7 +43,7 @@ Replace the single-shot query with an interactive terminal loop:
 
 **PRD:** `docs/prds/todd-tools.md`
 
-Register tools with the Agent SDK so todd can act on the filesystem:
+Register tools with the Strands Agent SDK so todd can act on the filesystem:
 - Read, Write, Edit — file operations
 - Bash — shell command execution
 - Glob, Grep — search operations
@@ -123,7 +123,7 @@ As you build, these operational skills will be useful:
 ## Further Reading
 
 - [Claude Code docs](https://code.claude.com/docs/en) — the product you're cloning
-- [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk) — the library powering todd
+- [Strands Agent SDK](https://github.com/strands-agents/sdk-python) — the library powering todd
 - IDE integrations: VS Code extension, JetBrains plugin
 - Plugins: `/plugin` marketplace for shared skills
 


### PR DESCRIPTION
## Summary
- Update module6.md Agent SDK references to Strands
- Migrate all todd PRDs from claude-agent-sdk to strands-agents

## Changes
- modules/module6.md: 3 SDK name/link updates
- docs/prds/todd-repl.md: dependency update
- docs/prds/todd-tools.md: 3 edits (name + hello command + dependency)
- docs/prds/todd-streaming.md: dependency update
- docs/prds/todd-context.md: dependency update
- docs/prds/todd-sessions.md: dependency update