### PR TITLE
docs(module-6): restore PRDs lost during propagation

### DIFF
--- a/docs/prds/adw-bug.md
+++ b/docs/prds/adw-bug.md
@@ -1,0 +1,97 @@
+---
+# PRD: ADW Bug Orchestrator
+
+## Overview
+
+Create a Python script that implements code-driven orchestration for bug fixes:
+
+- `adw_bug.py` — 6-phase sequential workflow script (no design phase)
+- Reuses `adw_core.py` from the feature orchestrator for state management,
+  phase invocation, ID generation, and logging
+
+This script is the *output* of running `/feature @docs/prds/adw-bug.md` in
+Module 4 of the workshop. It follows the same patterns as `adw_feature.py`
+but skips the design phase — appropriate for bugs where the fix is scoped
+to a known root cause rather than requiring architectural design work.
+
+## Usage
+
+```shell
+# Bug fix workflow
+uv run python adw_bug.py "Fix timeout on large file uploads"
+
+# Resume a failed or interrupted run
+uv run python adw_bug.py --resume cc73faf1
+```
+
+## Requirements
+
+### State Management
+
+Reuses `adw_core.py`. State schema is identical to the feature orchestrator:
+
+```json
+{
+  "adw_id": "cc73faf1",
+  "issue": "Fix timeout on large file uploads",
+  "plan_file": "docs/plans/cc73faf1-fix-timeout.md",
+  "issue_class": "bug",
+  "model": "opus",
+  "current_phase": "implement",
+  "completed_phases": ["research", "plan", "validation"],
+  "status": "in_progress"
+}
+```
+
+### Workflow Phases
+
+`adw_bug.py` runs these phases in order:
+
+1. `research` — Investigate the bug and its root cause
+2. `plan` — Create a phased fix plan
+3. `validation` — Verify the plan addresses the root cause
+4. `implement` — TDD implementation with atomic commits
+5. `review` — Code quality, security, and test coverage review
+6. `document` — Update documentation to reflect changes
+
+### Flags
+
+- `--resume <adw_id>` — read existing state and restart from `current_phase`
+- No `--from-design` flag (not applicable for bug fixes)
+
+### Phase Invocation
+
+- Each phase invoked via subprocess: `claude -p /<phase_name> <issue>`
+  — headless, no `-w` flag, runs in the current (worktree) directory
+- Phases execute sequentially — one must complete before the next starts
+- Non-zero exit from a phase halts the workflow and updates `status` to `failed`
+- Capture stdout/stderr and append to `agents/{adw_id}/{phase}/raw_output.jsonl`
+
+> **How the orchestrator is launched (not the phases).** Module 4 runs the
+> orchestrator inside a worktree: `claude -w {adw_id}`. Individual phase
+> invocations do NOT use `-w` — they run headlessly in the current directory.
+
+### Non-Functional
+
+- Fail with a clear error message if `claude` CLI is not on PATH
+- Log phase transitions to stderr with timestamps
+- Multiple ADWs can run in parallel without branch or filesystem conflicts
+
+## Dependencies
+
+Requires `adw_core.py` (built by the feature orchestrator PRD). Import shared
+utilities rather than duplicating them.
+
+## Implementation Notes
+
+Import from `adw_core` for all shared functionality. The only difference from
+`adw_feature.py` is the phase list (6 phases, no design) and the absence of
+the `--from-design` flag.
+
+## Out of Scope
+
+- Design phase (intentionally excluded — bugs don't require architectural design)
+- `--from-design` flag
+- GitHub PR creation at workflow end
+- Custom model selection per phase
+---

--- a/docs/prds/adw-commands.md
+++ b/docs/prds/adw-commands.md
@@ -1,0 +1,103 @@
+---
+# PRD: ADW Orchestration Commands
+
+## Overview
+
+Create four slash commands that compose the existing ADW phase commands
+(`/research`, `/design`, `/plan`, `/validation`, `/implement`, `/review`,
+`/document`) into end-to-end delivery workflows. Two strategies:
+
+1. **Single-agent sequential** (`/feature`, `/bug`) — one Claude instance
+   executes phases in order via prose instructions.
+2. **Multi-agent parallel** (`/team:feature`, `/team:bug`) — a leader agent
+   coordinates specialist workers using `TeamCreate`, `TaskCreate`, and
+   `SendMessage`.
+
+## Commands
+
+### `/feature` — Single-Agent Feature Delivery
+
+Location: `.claude/commands/feature.md`
+
+Phases: research → design → plan → validation → implement → review → document
+
+Accepts `$ARGUMENTS` as the feature description (or `@file` for a PRD).
+Executes phases sequentially. Carries context forward between phases via
+inline summaries.
+
+### `/bug` — Single-Agent Bug Fix
+
+Location: `.claude/commands/bug.md`
+
+Phases: research → plan → validation → implement → review → document
+
+Same as `/feature` but skips the design phase. Accepts `$ARGUMENTS` as the
+bug description (or `@file` for a PRD).
+
+### `/team:feature` — Multi-Agent Feature Delivery
+
+Location: `.claude/commands/team:feature.md`
+
+**Group 1 — Parallel Analysis** (4 workers run simultaneously):
+
+| Worker | Perspective | Maps to Phase |
+|--------|------------|---------------|
+| Researcher | Codebase exploration, prior art, constraints | `/research` |
+| Designer | Architecture, interfaces, data models | `/design` |
+| Planner | Implementation phases, commit strategy, test plan | `/plan` |
+| Validator | Risk assessment, edge cases, compatibility | `/validation` |
+
+Leader synthesises Group 1 outputs into a unified brief.
+
+**Group 2 — Coordinated Implementation** (3 workers):
+
+| Worker | Responsibility | Maps to Phase |
+|--------|---------------|---------------|
+| Implementer | TDD implementation following the synthesised plan | `/implement` |
+| Reviewer | Code review of implementation changes | `/review` |
+| Documenter | Documentation updates for changes | `/document` |
+
+Workers coordinate via `SendMessage`. Leader produces final summary.
+
+### `/team:bug` — Multi-Agent Bug Fix
+
+Location: `.claude/commands/team:bug.md`
+
+Same as `/team:feature` but Group 1 has 3 workers (no Designer). Phases:
+research + plan + validation (parallel) → implement + review + document
+(coordinated).
+
+## Requirements
+
+### Command Structure
+
+- Each command lives at `.claude/commands/<name>.md`
+- All commands accept `$ARGUMENTS` (description or `@file` PRD reference)
+- Commands MUST NOT set `context: fork` in frontmatter — all four commands
+  run in the primary context so team activity remains visible to the user
+- Single-agent commands execute phases sequentially with context handoff
+- Team commands use `TeamCreate` for setup, `TaskCreate` for work items,
+  `SendMessage` for coordination
+
+### Team Behavioural Requirements
+
+- Group 1 workers MUST run in parallel (not sequentially)
+- Group 2 starts only after leader synthesises Group 1 outputs
+- Each worker receives the original description plus leader context
+- Leader produces a final summary when all workers complete
+
+### Context Handoff (single-agent commands)
+
+Between phases, carry forward:
+- Key findings and decisions
+- File paths created or modified
+- Issues or blockers identified
+
+## Out of Scope
+
+- State file persistence between sessions
+- Python orchestrator scripts (these are the *work items* the commands build
+  in Module 4, not part of the commands themselves)
+- Worktree isolation (handled by the invoker, not the command)
+- Resumability from mid-workflow
+---

--- a/docs/prds/adw-feature.md
+++ b/docs/prds/adw-feature.md
@@ -1,0 +1,108 @@
+---
+# PRD: ADW Feature Orchestrator
+
+## Overview
+
+Create two Python scripts that implement code-driven orchestration for feature
+delivery:
+
+- `adw_feature.py` — 7-phase sequential workflow script
+- `adw_core.py` — shared module for state management, phase invocation, ID
+  generation, and logging
+
+These scripts are the *output* of running `/team:feature @docs/prds/adw-feature.md`
+in Module 4 of the workshop. They represent code-driven orchestration: where
+Module 3's commands describe workflows in prose, these scripts implement them
+in Python with state persistence and resumability.
+
+## Usage
+
+```shell
+# Full feature delivery
+uv run python adw_feature.py "Add retry logic to HTTP client"
+
+# Skip research and design — human has already produced a spec
+uv run python adw_feature.py --from-design "Add retry logic to HTTP client"
+
+# Resume a failed or interrupted run
+uv run python adw_feature.py --resume cc73faf1
+```
+
+## Requirements
+
+### State Management
+
+- Each workflow run gets a unique 8-character hex ADW ID (e.g. `cc73faf1`)
+- State persists at `agents/{adw_id}/state.json` with schema:
+  ```json
+  {
+    "adw_id": "cc73faf1",
+    "issue": "Add retry logic to HTTP client",
+    "plan_file": "docs/plans/cc73faf1-add-retry.md",
+    "issue_class": "feature",
+    "model": "opus",
+    "current_phase": "implement",
+    "completed_phases": ["research", "design", "plan", "validation"],
+    "status": "in_progress"
+  }
+  ```
+- Phase output captured to `agents/{adw_id}/{phase}/raw_output.jsonl`
+- State file must be valid JSON at all times (atomic write: temp file + rename)
+
+### Workflow Phases
+
+`adw_feature.py` runs these phases in order:
+
+1. `research` — Explore codebase and gather context
+2. `design` — Produce a technical specification
+3. `plan` — Create a phased implementation plan
+4. `validation` — Verify plan quality and traceability
+5. `implement` — TDD implementation with atomic commits
+6. `review` — Code quality, security, and test coverage review
+7. `document` — Update documentation to reflect changes
+
+### Flags
+
+- `--from-design` — skip research and design phases; start from `plan`
+- `--resume <adw_id>` — read existing state and restart from `current_phase`
+
+### Phase Invocation
+
+- Each phase invoked via subprocess: `claude -p /<phase_name> <issue>`
+  — headless, no `-w` flag, runs in the current (worktree) directory
+- Phases execute sequentially — one must complete before the next starts
+- Non-zero exit from a phase halts the workflow and updates `status` to `failed`
+- Capture stdout/stderr and append to `agents/{adw_id}/{phase}/raw_output.jsonl`
+
+> **How the orchestrator is launched (not the phases).** Module 4 runs the
+> orchestrator inside a worktree: `claude -w {adw_id}`. Individual phase
+> invocations do NOT use `-w` — they run headlessly in the current directory.
+
+### Non-Functional
+
+- Fail with a clear error message if `claude` CLI is not on PATH
+- Log phase transitions to stderr with timestamps
+- Multiple ADWs can run in parallel without branch or filesystem conflicts
+
+## Scripts
+
+Both scripts share `adw_core.py` which provides:
+- State management (create, read, update functions)
+- Phase invocation via `subprocess.run()`
+- ADW ID generation (8-char hex)
+- Atomic state writes (temp file + rename pattern)
+- Logging and error handling
+
+## Implementation Notes
+
+Use `subprocess.run()` to invoke `claude -p /<phase>`. Capture stdout/stderr
+and write to JSONL output files. Update state before and after each phase
+invocation to support resumability.
+
+## Out of Scope
+
+- Multi-agent team orchestration (that is what invokes this script in Module 4)
+- GitHub PR creation at workflow end
+- Parallel phase execution (phases are always sequential)
+- Custom model selection per phase
+---


### PR DESCRIPTION
adw-commands.md, adw-feature.md, and adw-bug.md were deleted when upstream PRD cleanup propagated through. Restoring — module-6 needs all PRDs.