### PR TITLE
fix(setup): simplify awsAuthRefresh and add CLAUDE_CODE_GIT_BASH_PATH for Windows

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -69,7 +69,7 @@ Configure claude to utilize this profile by creating/updating the following sett
 
 ```json
 {
-  "awsAuthRefresh": "aws sso login --profile ${AWS_PROFILE}",
+  "awsAuthRefresh": "aws-sso-util login",
   "env": {
     "AWS_REGION": "<SSO_REGION>",
     "AWS_PROFILE": "<CHANGE TO THE AWS PROFILE YOU WOULD LIKE TO USE FOR BEDROCK>",
@@ -81,8 +81,8 @@ Configure claude to utilize this profile by creating/updating the following sett
 }
 ```
 
-> **Windows / PowerShell users:** Replace the `awsAuthRefresh` value with:
-> ```json
-> "awsAuthRefresh": "aws sso login --profile $env:AWS_PROFILE"
-> ```
-> PowerShell uses `$env:VAR` instead of `${VAR}` for environment variable expansion.
+> **Windows users:** If Claude Code cannot find Git Bash, add `CLAUDE_CODE_GIT_BASH_PATH`
+> to the `env` block pointing to your `bash.exe`. Recent Git for Windows installs via winget
+> or GitHub Desktop place it at `%LOCALAPPDATA%\Programs\Git\bin\bash.exe` rather than
+> `C:\Program Files\Git\bin\bash.exe`. The automated setup script detects and sets this
+> automatically.

--- a/setup/configure.py
+++ b/setup/configure.py
@@ -36,15 +36,10 @@ BEDROCK_ENV: dict[str, str] = {
     "CLAUDE_CODE_USE_BEDROCK": "1",
 }
 
-def _auth_refresh_command() -> str:
-    """Return the awsAuthRefresh command for the current platform."""
-    if sys.platform == "win32":
-        return "aws sso login --profile $env:AWS_PROFILE"
-    return "aws sso login --profile ${AWS_PROFILE}"
-
+AUTH_REFRESH_COMMAND = "aws-sso-util login"
 
 BEDROCK_ENV_KEYS: dict[str, str | dict[str, str]] = {
-    "awsAuthRefresh": _auth_refresh_command(),
+    "awsAuthRefresh": AUTH_REFRESH_COMMAND,
     "env": BEDROCK_ENV,
 }
 
@@ -108,6 +103,43 @@ class ProfileSelector(App[str]):  # type: ignore[misc]
         self.exit(result=str(event.option.prompt))
 
 
+def _find_git_bash() -> str | None:
+    """Find bash.exe from Git for Windows.
+
+    Checks known install locations first, then falls back to a recursive
+    search of common root directories (suppressing permission errors).
+    """
+    # Fast path: check known locations
+    candidates = [
+        Path.home() / "AppData/Local/Programs/Git/bin/bash.exe",
+        Path("C:/Program Files/Git/bin/bash.exe"),
+        Path("C:/Program Files (x86)/Git/bin/bash.exe"),
+    ]
+    for path in candidates:
+        if path.exists():
+            return str(path)
+
+    # Slow path: search AppData then Program Files
+    from rich.console import Console  # type: ignore[import-not-found]
+
+    console = Console()
+    search_roots = [
+        Path.home() / "AppData",
+        Path("C:/Program Files"),
+        Path("C:/Program Files (x86)"),
+    ]
+    with console.status("[bold cyan]Searching for Git Bash..."):
+        for root in search_roots:
+            if not root.exists():
+                continue
+            try:
+                for hit in root.rglob("Git/bin/bash.exe"):
+                    return str(hit)
+            except PermissionError:
+                continue
+    return None
+
+
 def merge_settings(settings_path: Path, profile: str, region: str):
     """Merge Bedrock config into existing settings.json or create new.
 
@@ -136,6 +168,12 @@ def merge_settings(settings_path: Path, profile: str, region: str):
     bedrock_env["AWS_REGION"] = region
 
     merged["env"].update(bedrock_env)
+
+    # Add Git Bash path on Windows so Claude Code can find it
+    if sys.platform == "win32":
+        git_bash = _find_git_bash()
+        if git_bash:
+            merged["env"]["CLAUDE_CODE_GIT_BASH_PATH"] = git_bash
 
     # Ensure parent directory exists
     settings_path.parent.mkdir(parents=True, exist_ok=True)

--- a/setup/test_configure.py
+++ b/setup/test_configure.py
@@ -12,10 +12,7 @@ sys.path.insert(0, str(REPO_ROOT))
 import configure  # noqa: E402
 
 
-def _expected_auth_refresh() -> str:
-    if sys.platform == "win32":
-        return "aws sso login --profile $env:AWS_PROFILE"
-    return "aws sso login --profile ${AWS_PROFILE}"
+EXPECTED_AUTH_REFRESH = "aws-sso-util login"
 
 
 def test_parse_sso_profiles_empty_file(tmp_path: Path) -> None:
@@ -87,7 +84,7 @@ def test_merge_settings_creates_new_file(tmp_path: Path) -> None:
     assert settings_path.parent.exists()
 
     data = json.loads(settings_path.read_text())
-    assert data["awsAuthRefresh"] == _expected_auth_refresh()
+    assert data["awsAuthRefresh"] == EXPECTED_AUTH_REFRESH
     assert data["env"]["AWS_PROFILE"] == "test.Profile"
     assert data["env"]["AWS_REGION"] == "us-west-2"
     assert data["env"]["CLAUDE_CODE_USE_BEDROCK"] == "1"
@@ -153,7 +150,7 @@ def test_merge_settings_overwrites_bedrock_keys(tmp_path: Path) -> None:
 
     result = configure.merge_settings(settings_path, "new.Profile", "us-west-2")
 
-    assert result["awsAuthRefresh"] == _expected_auth_refresh()
+    assert result["awsAuthRefresh"] == EXPECTED_AUTH_REFRESH
     assert result["env"]["AWS_PROFILE"] == "new.Profile"
     assert result["env"]["AWS_REGION"] == "us-west-2"
     assert result["env"]["CLAUDE_CODE_USE_BEDROCK"] == "1"
@@ -169,4 +166,4 @@ def test_merge_settings_handles_malformed_json(tmp_path: Path) -> None:
 
     # Should create fresh config despite malformed input
     assert result["env"]["AWS_PROFILE"] == "test.Profile"
-    assert result["awsAuthRefresh"] == _expected_auth_refresh()
+    assert result["awsAuthRefresh"] == EXPECTED_AUTH_REFRESH


### PR DESCRIPTION
## Summary

- Replaces platform-branching `_auth_refresh_command()` with `AUTH_REFRESH_COMMAND = "aws-sso-util login"` — reads `AWS_PROFILE` from the inherited environment, no shell expansion needed on any platform
- Adds `_find_git_bash()` helper for Windows: checks user-local `AppData/Local/Programs/Git` first (winget/GitHub Desktop installs), then falls back to `C:\Program Files\Git`, with a Rich spinner for the filesystem search
- Updates `SETUP.md` manual JSON to use `aws-sso-util login`, removes PowerShell callout, adds Git Bash path note for Windows users

## Test plan

- [x] All 8 existing tests pass (`uv run --with pytest --with typer --with textual pytest setup/test_configure.py -v`)
- [x] No references to old `_auth_refresh_command()` or PowerShell expansion remain