### PR TITLE
fix(statusline): replace PS1 with bash script using sed/awk for Git Bash

### DIFF
--- a/modules/module1.md
+++ b/modules/module1.md
@@ -188,16 +188,10 @@ In the chat box, run:
 > There are many other built-in slash commands you can see if you just type `/` in the chat window.
 > For a full list, see the [Anthropic docs on slash commands](https://code.claude.com/docs/en/interactive-mode#built-in-commands).
 
-> **Windows / PowerShell users — two options:**
->
-> **Option A (Prompt):** Run `/statusline` with the full prompt and a Windows constraint:
+> **Windows users (Git Bash):** Use the pre-built script — `sed` and `awk` only, no Python or jq needed.
+> Paste this into the Claude chat box:
 > ```
-> /statusline Show {model short name} | {context}% context | {cwd} | {git_status} | {branch} where git status is green "clean" or yellow "modified" using ANSI colors, and omit git fields if not in a repo. Use PowerShell-compatible syntax — avoid backticks and ANSI escape sequences.
-> ```
->
-> **Option B (Pre-built script):** Paste this into the Claude chat box:
-> ```
-> Copy scripts/statusline.ps1 to ~/.claude/statusline.ps1 and add a statusLine entry to ~/.claude/settings.json that runs it with pwsh.
+> Copy scripts/statusline.sh to ~/.claude/statusline.sh and add a statusLine entry to ~/.claude/settings.json: { "statusLine": { "type": "command", "command": "bash ~/.claude/statusline.sh" } }
 > ```
 
 > **Pro tip:** Type `/cost` to see token usage and spend for this session, or

--- a/scripts/statusline.sh
+++ b/scripts/statusline.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# statusline.sh
+# Git Bash statusline for Claude Code (Windows).
+# Claude Code pipes JSON session data to stdin; this script writes one line to stdout.
+#
+# Install: copy to ~/.claude/statusline.sh
+# Settings:
+#   { "statusLine": { "type": "command", "command": "bash ~/.claude/statusline.sh" } }
+#
+# Requirements: bash, sed, awk, git — all present in Git for Windows. No Python or jq needed.
+
+GREEN=$'\033[0;32m'
+YELLOW=$'\033[0;33m'
+RESET=$'\033[0m'
+
+# Read all stdin as a single line for sed processing
+json=$(cat | tr -d '\n')
+
+# Extract fields with sed — no Python or jq required
+model=$(printf '%s' "$json" | sed -n 's/.*"display_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+pct=$(printf '%s' "$json"   | sed -n 's/.*"used_percentage"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p')
+raw_dir=$(printf '%s' "$json" | sed -n 's/.*"current_dir"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+
+# Defaults when fields are absent
+[ -z "$model" ]   && model="claude"
+[ -z "$pct" ]     && pct="0"
+[ -z "$raw_dir" ] && raw_dir="$PWD"
+
+# Normalise Windows backslashes to forward slashes
+raw_dir=$(printf '%s' "$raw_dir" | sed 's|\\|/|g')
+
+# Abbreviate home directory to ~
+cwd="${raw_dir/#$HOME/\~}"
+
+# Truncate deep paths: more than 3 components → .../<parent>/<last>
+cwd=$(printf '%s' "$cwd" | awk -F'/' 'NF > 3 { print ".../" $(NF-1) "/" $NF; next } { print }')
+
+# Git info with ANSI colours (omitted if not in a repo or git unavailable)
+git_part=""
+if command -v git >/dev/null 2>&1; then
+  if git -C "$raw_dir" rev-parse --git-dir >/dev/null 2>&1; then
+    branch=$(git -C "$raw_dir" branch --show-current 2>/dev/null)
+    if [ -n "$(git -C "$raw_dir" status --porcelain 2>/dev/null)" ]; then
+      state="${YELLOW}modified${RESET}"
+    else
+      state="${GREEN}clean${RESET}"
+    fi
+    git_part=" | ${state} | ${branch}"
+  fi
+fi
+
+printf '%s | %s%% context | %s%s\n' "$model" "$pct" "$cwd" "$git_part"


### PR DESCRIPTION
## Summary

- Adds `scripts/statusline.sh` — a pure bash/sed/awk implementation of the statusline for Git Bash on Windows. No Python or jq required.
- Replaces the Windows callout in `modules/module1.md` to reference the bash script instead of the PS1/pwsh approach.

## Why

Claude Code uses Git Bash on Windows (via `CLAUDE_CODE_GIT_BASH_PATH`). Git Bash ships with bash, sed, awk, and git — but not Python or jq. The previous `statusline.ps1` required PowerShell (`pwsh`), which is a separate dependency and uses a different execution environment.

## Script behaviour

- Parses JSON from stdin using `sed -n 's/.../\1/p'` patterns — no external JSON tools
- Normalises Windows backslashes to forward slashes via `sed 's|\\|/|g'`
- Abbreviates `$HOME` to `~`, truncates paths deeper than 3 components to `.../<parent>/<last>`
- ANSI-coloured git status (green clean / yellow modified); omitted if not in a repo