### PR TITLE
refactor: convert commands to user-invocable skills (main)

### DIFF
--- a/.claude/skills/begin/SKILL.md
+++ b/.claude/skills/begin/SKILL.md
@@ -1,5 +1,7 @@
 ---
+name: begin
 description: Start the workshop by switching to module-1 without carrying forward setup changes.
+disable-model-invocation: true
 ---
 # Purpose
 

--- a/.claude/skills/propagate/SKILL.md
+++ b/.claude/skills/propagate/SKILL.md
@@ -1,5 +1,7 @@
 ---
+name: propagate
 description: Propagate changes from the current module branch forward through all downstream module branches via PRs.
+disable-model-invocation: true
 ---
 # Purpose
 


### PR DESCRIPTION
## Summary

- Converts `.claude/commands/begin.md` and `.claude/commands/propagate.md` to skills
- Creates `.claude/skills/begin/SKILL.md` and `.claude/skills/propagate/SKILL.md`
- Both skills have `disable-model-invocation: true` (workshop-management, explicit invocation only)
- Removes `.claude/commands/` directory (now empty)

## Test plan
- [ ] `git show main:.claude/skills/begin/SKILL.md` — confirm skill exists after merge
- [ ] `git show main:.claude/commands/` — confirm commands directory is gone