### PR TITLE
refactor: convert phase commands to user-invocable skills

### DIFF
--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -1,6 +1,0 @@
----
-description: Just testing something
----
-Write a test file to ${CLAUDE_SESSION_ID}-test.md 
-
-Include the contents "Hello world"

--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: design
 description: Design architecture and produce technical specifications
 context: fork
 ---

--- a/.claude/skills/document/SKILL.md
+++ b/.claude/skills/document/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: document
 description: Update documentation to reflect implementation changes
 context: fork
 agent: documentation

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: implement
 description: Implement a plan using TDD methodology with atomic commits per phase
 context: fork
 agent: implementation

--- a/.claude/skills/plan/SKILL.md
+++ b/.claude/skills/plan/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: plan
 description: Create a phased implementation plan with atomic commits
 context: fork
 ---

--- a/.claude/skills/research/SKILL.md
+++ b/.claude/skills/research/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: research
 description: Research codebase and documentation to answer questions and gather context
 context: fork
 ---

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: review
 description: Code review with multi-dimensional quality, security, and test analysis
 context: fork
 agent: validation

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: test
+description: Just testing something
+---
+Write a test file to ${CLAUDE_SESSION_ID}-test.md
+
+Include the contents "Hello world"

--- a/.claude/skills/validation/SKILL.md
+++ b/.claude/skills/validation/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: validation
 description: Validate an implementation plan for quality, atomicity, and traceability
 context: fork
 agent: validation


### PR DESCRIPTION
## Summary

Converts all 8 phase commands to skills on module-3:

| Command | Skill |
|---------|-------|
| `.claude/commands/design.md` | `.claude/skills/design/SKILL.md` |
| `.claude/commands/document.md` | `.claude/skills/document/SKILL.md` |
| `.claude/commands/implement.md` | `.claude/skills/implement/SKILL.md` |
| `.claude/commands/plan.md` | `.claude/skills/plan/SKILL.md` |
| `.claude/commands/research.md` | `.claude/skills/research/SKILL.md` |
| `.claude/commands/review.md` | `.claude/skills/review/SKILL.md` |
| `.claude/commands/test.md` | `.claude/skills/test/SKILL.md` |
| `.claude/commands/validation.md` | `.claude/skills/validation/SKILL.md` |

Phase skills remain auto-invocable (no `disable-model-invocation`). Removes `.claude/commands/`.

## Test plan
- [ ] Confirm all 8 skills exist at `.claude/skills/<name>/SKILL.md`
- [ ] Confirm `.claude/commands/` directory is gone